### PR TITLE
Command-, as a hotkey to open the settings page

### DIFF
--- a/apps/desktop/src/components/root/AppSideEffects.tsx
+++ b/apps/desktop/src/components/root/AppSideEffects.tsx
@@ -98,5 +98,16 @@ export const AppSideEffects = () => {
     },
   });
 
+  // Hotkey to open settings (Cmd+, on macOS)
+  useKeyDownHandler({
+    keys: [","],
+    meta: true,
+    callback: () => {
+      if (window.location.pathname !== "/dashboard/settings") {
+        window.location.href = "/dashboard/settings";
+      }
+    },
+  });
+
   return null;
 };


### PR DESCRIPTION
Added command-, as a hotkey to open the settings page from within the app.