### PR TITLE
fix(desktop): add missing libxdo3 dependency for Linux deb bundle

### DIFF
--- a/apps/desktop/src-tauri/tauri.prod.conf.json
+++ b/apps/desktop/src-tauri/tauri.prod.conf.json
@@ -2,6 +2,13 @@
   "productName": "Voquill",
   "identifier": "com.voquill.desktop",
   "mainBinaryName": "Voquill",
+  "bundle": {
+    "linux": {
+      "deb": {
+        "depends": ["libxdo3"]
+      }
+    }
+  },
   "plugins": {
     "updater": {
       "endpoints": [


### PR DESCRIPTION
### The Issue

After downloading and installing the `.deb` package from the latest release on **Kubuntu 24.04 LTS**, the application failed to launch via the GUI.

Running `Voquill` from the terminal revealed a missing shared library error regarding `libxdo`:

```bash
$ Voquill 
Voquill: error while loading shared libraries: libxdo.so.3: cannot open shared object file: No such file or directory
```

The application relies on `rdev`/`enigo` (or similar crates for input simulation) which dynamically link to `libxdo`, but `libxdo3` was not listed as a package dependency in the generated Debian control file.

### Fix

I have updated `apps/desktop/src-tauri/tauri.prod.conf.json` to explicitly include `libxdo3` in the linux bundle configuration.

### Environment

Testing was performed on the following machine:

* **OS:** Kubuntu 24.04.3 LTS (Noble Numbat)
* **Kernel:** Linux 6.8.0-79-generic
* **Architecture:** x86_64

### Verification

I built the package locally using `tauri build` with the prod config and verified the generated `.deb` metadata.

**Before (Official Release):**
```bash
$ dpkg-deb -I Voquill_0.0.245_amd64.deb | grep Depends
 Depends: libayatana-appindicator3-1, libwebkit2gtk-4.1-0, libgtk-3-0
```

**After (This PR):**
```bash
$ dpkg-deb -I ../Code/voquill/apps/desktop/src-tauri/target/release/bundle/deb/Voquill_0.1.0_amd64.deb | grep Depends 
 Depends: libxdo3, libayatana-appindicator3-1, libwebkit2gtk-4.1-0, libgtk-3-0
```

The generated package now correctly declares `libxdo3` as a dependency, allowing `apt` to install it automatically.
