### PR TITLE
fix input device filtering and descriptor serialization

### DIFF
--- a/apps/desktop/src-tauri/src/platform/audio.rs
+++ b/apps/desktop/src-tauri/src/platform/audio.rs
@@ -336,6 +336,10 @@ const LOW_QUALITY_INPUT_KEYWORDS: &[&str] = &[
     "hfp",
     "hsp",
     "sony wh-",
+    // Linux virtual devices that don't provide real microphone input
+    "monitor of", // PulseAudio monitor (captures output audio, not microphone)
+    "samplerate", // ALSA samplerate converter
+    "null",       // Null audio device
 ];
 
 fn should_avoid_input_device(device: &Device, default_output_name: Option<&str>) -> bool {
@@ -586,7 +590,7 @@ fn device_candidates_for_host(
             .map(|pref| {
                 normalized_name
                     .as_ref()
-                    .map(|label| label == pref)
+                    .map(|label| label.contains(pref) || pref.contains(label))
                     .unwrap_or(false)
             })
             .unwrap_or(false);
@@ -632,7 +636,7 @@ fn device_candidates_for_host(
                 .map(|pref| {
                     normalized_name
                         .as_ref()
-                        .map(|label| label == pref)
+                        .map(|label| label.contains(pref) || pref.contains(label))
                         .unwrap_or(false)
                 })
                 .unwrap_or(false);
@@ -671,6 +675,7 @@ fn device_candidates_for_host(
 }
 
 #[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct InputDeviceDescriptor {
     pub label: String,
     pub is_default: bool,


### PR DESCRIPTION
Fixed Linux audio device selection issues in apps/desktop/src-tauri/src/platform/audio.rs by making three changes: (1) added #[serde(rename_all = "camelCase")] to InputDeviceDescriptor struct to fix a serialization mismatch where Rust was sending is_default but TypeScript expected isDefault, (2) changed device name matching from exact string equality to bidirectional substring matching (label.contains(pref) || pref.contains(label)) so that saved device preferences like "USB Microphone" still match when ALSA/PulseAudio returns names with hardware suffixes like "USB Microphone (hw:1,0)", and (3) added Linux-specific virtual device keywords ("monitor of", "samplerate", "null") to the LOW_QUALITY_INPUT_KEYWORDS filter to prevent the app from trying to record from PulseAudio monitor devices and ALSA virtual converters that don't provide actual microphone input, which was causing timeouts in automatic mode.

Closes #36 