### PR TITLE
fix: update accessibility.rs to correct property value access

### DIFF
--- a/apps/desktop/src-tauri/src/platform/windows/accessibility.rs
+++ b/apps/desktop/src-tauri/src/platform/windows/accessibility.rs
@@ -275,7 +275,7 @@ fn get_control_type(element: &IUIAutomationElement) -> i32 {
         element
             .GetCurrentPropertyValue(UIA_ControlTypePropertyId)
             .ok()
-            .and_then(|v| v.as_raw().Anonymous.Anonymous.Anonymous.lVal.try_into().ok())
+            .and_then(|v| v.Anonymous.Anonymous.Anonymous.lVal.try_into().ok())
             .unwrap_or(0)
     }
 }
@@ -286,9 +286,8 @@ fn get_element_name(element: &IUIAutomationElement) -> Option<String> {
             .GetCurrentPropertyValue(UIA_NamePropertyId)
             .ok()
             .and_then(|v| {
-                let bstr = BSTR::from_raw(*v.as_raw().Anonymous.Anonymous.Anonymous.bstrVal);
-                let s = bstr.to_string();
-                std::mem::forget(bstr);
+                let bstr_ref = &v.Anonymous.Anonymous.Anonymous.bstrVal;
+                let s = bstr_ref.to_string();
                 if s.is_empty() {
                     None
                 } else {


### PR DESCRIPTION
This pull request includes minor refactoring to how property values are accessed from the `IUIAutomationElement` in the Windows accessibility platform code. The changes remove unnecessary use of `as_raw()` and simplify handling of property value fields.

- **Refactoring property value access:**
  - Replaced the use of `.as_raw()` when accessing the `lVal` and `bstrVal` fields of property values in `get_control_type` and `get_element_name`, respectively, to access the fields directly and simplify the code. [[1]](diffhunk://#diff-f2047e9a3a67a9011f19a7a6879e642b19f7b5f2fe7fa10be62f626ee45cf58eL278-R278) [[2]](diffhunk://#diff-f2047e9a3a67a9011f19a7a6879e642b19f7b5f2fe7fa10be62f626ee45cf58eL289-R290)