### PR TITLE
fix(windows): avoid overlay click-through toggle; add Esc close for agent panel

### DIFF
--- a/apps/desktop/src/components/overlay/AgentSection.tsx
+++ b/apps/desktop/src/components/overlay/AgentSection.tsx
@@ -17,8 +17,10 @@ import { useAppStore } from "../../store";
 import type { AgentWindowMessage } from "../../types/agent-window.types";
 import {
   AGENT_DICTATE_HOTKEY,
+  AGENT_OVERLAY_CLOSE_HOTKEY,
   getHotkeyCombosForAction,
 } from "../../utils/keyboard.utils";
+import { getPlatform } from "../../utils/platform.utils";
 import { AudioWaveform } from "../common/AudioWaveform";
 import { HotkeyBadge } from "../common/HotkeyBadge";
 
@@ -297,6 +299,11 @@ export const AgentSection = forwardRef<HTMLDivElement>((_, ref) => {
   const hotkeyCombos = useAppStore((state) =>
     getHotkeyCombosForAction(state, AGENT_DICTATE_HOTKEY),
   );
+  const closeHotkeyCombos = useAppStore((state) =>
+    getHotkeyCombosForAction(state, AGENT_OVERLAY_CLOSE_HOTKEY),
+  );
+
+  const isWindows = getPlatform() === "windows";
 
   const isVisible = phase !== "idle";
   const isRecording = phase === "recording";
@@ -438,6 +445,7 @@ export const AgentSection = forwardRef<HTMLDivElement>((_, ref) => {
           <IconButton
             onClick={handleClose}
             size="small"
+            disabled={isWindows}
             sx={{
               width: 24,
               height: 24,
@@ -448,7 +456,14 @@ export const AgentSection = forwardRef<HTMLDivElement>((_, ref) => {
               },
             }}
           >
-            <CloseIcon sx={{ fontSize: 14 }} />
+            {isWindows ? (
+              <HotkeyBadge
+                keys={closeHotkeyCombos[0] ?? ["Escape"]}
+                sx={{ fontSize: "0.65rem", py: 0, px: 0.5 }}
+              />
+            ) : (
+              <CloseIcon sx={{ fontSize: 14 }} />
+            )}
           </IconButton>
         </Box>
         <Box
@@ -539,19 +554,32 @@ export const AgentSection = forwardRef<HTMLDivElement>((_, ref) => {
                 display: "flex",
                 justifyContent: "flex-end",
                 mt: 1,
+                alignItems: "center",
+                gap: 1,
               }}
             >
-              <Button
-                variant="outlined"
-                size="small"
-                onClick={handleClose}
-                sx={{
-                  textTransform: "none",
-                  fontSize: "0.8125rem",
-                }}
-              >
-                Finish
-              </Button>
+              {isWindows ? (
+                <Typography variant="caption" sx={{ color: "text.secondary" }}>
+                  <FormattedMessage defaultMessage="Press" />{" "}
+                  <HotkeyBadge
+                    keys={closeHotkeyCombos[0] ?? ["Escape"]}
+                    sx={{ fontSize: "0.65rem", py: 0, px: 0.5 }}
+                  />{" "}
+                  <FormattedMessage defaultMessage="to close" />
+                </Typography>
+              ) : (
+                <Button
+                  variant="outlined"
+                  size="small"
+                  onClick={handleClose}
+                  sx={{
+                    textTransform: "none",
+                    fontSize: "0.8125rem",
+                  }}
+                >
+                  Finish
+                </Button>
+              )}
             </Box>
           )}
         </Box>

--- a/apps/desktop/src/components/root/RootSideEffects.ts
+++ b/apps/desktop/src/components/root/RootSideEffects.ts
@@ -1,5 +1,6 @@
 import { getRec } from "@repo/utilities";
 import { invoke } from "@tauri-apps/api/core";
+import { emitTo } from "@tauri-apps/api/event";
 import { isEqual } from "lodash-es";
 import { useCallback, useEffect, useMemo, useRef } from "react";
 import { useIntl } from "react-intl";
@@ -53,9 +54,11 @@ import {
 import { playAlertSound, tryPlayAudioChime } from "../../utils/audio.utils";
 import {
   AGENT_DICTATE_HOTKEY,
+  AGENT_OVERLAY_CLOSE_HOTKEY,
   DICTATE_HOTKEY,
   LANGUAGE_SWITCH_HOTKEY,
 } from "../../utils/keyboard.utils";
+
 import { isPermissionAuthorized } from "../../utils/permission.utils";
 import {
   getIsOnboarded,
@@ -432,6 +435,13 @@ export const RootSideEffects = () => {
     actionName: LANGUAGE_SWITCH_HOTKEY,
     isDisabled: !languageSwitchEnabled,
     onFire: handleLanguageSwitch,
+  });
+
+  useHotkeyFire({
+    actionName: AGENT_OVERLAY_CLOSE_HOTKEY,
+    onFire: () => {
+      emitTo("main", "agent-overlay-close", {}).catch(console.error);
+    },
   });
 
   useTauriListen<void>(REGISTER_CURRENT_APP_EVENT, async () => {

--- a/apps/desktop/src/components/settings/ShortcutsDialog.tsx
+++ b/apps/desktop/src/components/settings/ShortcutsDialog.tsx
@@ -1,21 +1,23 @@
 import {
-    Button,
-    CircularProgress,
-    Dialog,
-    DialogActions,
-    DialogContent,
-    DialogTitle,
-    Stack,
-    Typography,
+  Button,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Stack,
+  Typography,
 } from "@mui/material";
 import { FormattedMessage } from "react-intl";
 import { setLanguageSwitchEnabled } from "../../actions/user.actions";
 import { produceAppState, useAppStore } from "../../store";
 import {
-    AGENT_DICTATE_HOTKEY,
-    DICTATE_HOTKEY,
-    LANGUAGE_SWITCH_HOTKEY,
+  AGENT_DICTATE_HOTKEY,
+  AGENT_OVERLAY_CLOSE_HOTKEY,
+  DICTATE_HOTKEY,
+  LANGUAGE_SWITCH_HOTKEY,
 } from "../../utils/keyboard.utils";
+
 import { HotkeySetting } from "./HotkeySetting";
 
 export const ShortcutsDialog = () => {
@@ -66,6 +68,13 @@ export const ShortcutsDialog = () => {
             <FormattedMessage defaultMessage="Dictate commands for the AI to follow instead of just cleaning up text." />
           }
           actionName={AGENT_DICTATE_HOTKEY}
+        />
+        <HotkeySetting
+          title={<FormattedMessage defaultMessage="Close agent panel" />}
+          description={
+            <FormattedMessage defaultMessage="Close the agent panel (useful when the panel is not clickable on Windows)." />
+          }
+          actionName={AGENT_OVERLAY_CLOSE_HOTKEY}
         />
         <HotkeySetting
           title={

--- a/apps/desktop/src/hooks/overlay.hooks.ts
+++ b/apps/desktop/src/hooks/overlay.hooks.ts
@@ -11,6 +11,7 @@ import {
   useState,
   RefObject,
 } from "react";
+import { getPlatform } from "../utils/platform.utils";
 
 type ContentRef = RefObject<HTMLElement | null>;
 
@@ -27,9 +28,17 @@ export const useUnifiedClickThrough = ({
 }: UseUnifiedClickThroughOptions) => {
   const defaultWindowRef = useMemo(() => getCurrentWindow(), []);
   const windowRef = providedWindowRef ?? defaultWindowRef;
+  const platform = useMemo(() => getPlatform(), []);
 
   useEffect(() => {
     if (!enabled) return;
+
+    // Windows-specific: never toggle ignore cursor events.
+    // Toggling this on a transparent always-on-top window can cause the overlay to stop painting.
+    if (platform === "windows") {
+      windowRef.setIgnoreCursorEvents(true).catch(console.error);
+      return;
+    }
 
     let isOverContent = false;
     let animationFrame: number;
@@ -107,7 +116,7 @@ export const useUnifiedClickThrough = ({
       cancelAnimationFrame(animationFrame);
       windowRef.setIgnoreCursorEvents(true).catch(console.error);
     };
-  }, [windowRef, enabled, contentRefs]);
+  }, [windowRef, enabled, contentRefs, platform]);
 };
 
 type UseOverlayDragOptions = {

--- a/apps/desktop/src/utils/keyboard.utils.ts
+++ b/apps/desktop/src/utils/keyboard.utils.ts
@@ -3,6 +3,7 @@ import { getPlatform } from "./platform.utils";
 
 export const DICTATE_HOTKEY = "dictate";
 export const AGENT_DICTATE_HOTKEY = "agent-dictate";
+export const AGENT_OVERLAY_CLOSE_HOTKEY = "agent-overlay-close";
 export const LANGUAGE_SWITCH_HOTKEY = "language-switch";
 
 export const getPrettyKeyName = (key: string): string => {
@@ -45,6 +46,11 @@ export const DEFAULT_HOTKEY_COMBOS: Record<string, PlatformHotkeyCombos> = {
     macos: [["Function"]],
     windows: [["F8"]],
     linux: [["F8"]],
+  },
+  [AGENT_OVERLAY_CLOSE_HOTKEY]: {
+    macos: [["Escape"]],
+    windows: [["Escape"]],
+    linux: [["Escape"]],
   },
   [LANGUAGE_SWITCH_HOTKEY]: {
     macos: [["controlLeft", "ShiftLeft", "KeyL"]],


### PR DESCRIPTION
Solution for #74 on windows:

Implementation Details as follows:
setIgnoreCursorEvents on Windows
- keeps it click-through to avoid masking behavior
- feat(hotkeys): add AGENT_OVERLAY_CLOSE_HOTKEY with default Escape and wire it to emit agent-overlay-close
- ui(agent): on Windows, replace the clickable “Finish”/close affordance with an Esc hint/badge; keep existing clickable controls on macOS/Linux
