### PR TITLE
feat(linux): set window manager hints for desktop overlays

### DIFF
--- a/apps/desktop/src-tauri/src/platform/linux/window.rs
+++ b/apps/desktop/src-tauri/src/platform/linux/window.rs
@@ -1,7 +1,17 @@
 use gtk::gdk::ffi::GDK_CURRENT_TIME;
+use gtk::gdk::WindowTypeHint;
+use gtk::glib::IsA;
 use gtk::prelude::*;
 use std::sync::mpsc;
 use tauri::WebviewWindow;
+
+fn configure_overlay_window_manager_hints(gtk_window: &impl IsA<gtk::Window>) {
+    let gtk_window: &gtk::Window = gtk_window.as_ref();
+
+    gtk_window.set_skip_taskbar_hint(true);
+    gtk_window.set_skip_pager_hint(true);
+    gtk_window.set_type_hint(WindowTypeHint::Utility);
+}
 
 pub fn surface_main_window(window: &WebviewWindow) -> Result<(), String> {
     let window_for_handle = window.clone();
@@ -55,6 +65,7 @@ pub fn show_overlay_no_focus(window: &WebviewWindow) -> Result<(), String> {
                     .gtk_window()
                     .map_err(|err| err.to_string())?;
 
+                configure_overlay_window_manager_hints(&gtk_window);
                 gtk_window.set_accept_focus(false);
                 gtk_window.set_focus_on_map(false);
                 gtk_window.set_keep_above(true);
@@ -85,6 +96,7 @@ pub fn configure_overlay_non_activating(window: &WebviewWindow) -> Result<(), St
                     .gtk_window()
                     .map_err(|err| err.to_string())?;
 
+                configure_overlay_window_manager_hints(&gtk_window);
                 gtk_window.set_accept_focus(false);
                 gtk_window.set_focus_on_map(false);
 
@@ -99,7 +111,10 @@ pub fn configure_overlay_non_activating(window: &WebviewWindow) -> Result<(), St
         .map_err(|_| "failed to configure overlay as non-activating on main thread".to_string())?
 }
 
-pub fn set_overlay_click_through(window: &WebviewWindow, click_through: bool) -> Result<(), String> {
+pub fn set_overlay_click_through(
+    window: &WebviewWindow,
+    click_through: bool,
+) -> Result<(), String> {
     window
         .set_ignore_cursor_events(click_through)
         .map_err(|err| err.to_string())


### PR DESCRIPTION
## Summary

In Linux environments (GTK/KWin, etc.), Voquill's overlay (pill/toast/agent) windows, although transparent, undecorated, and non-focusable, can still be managed by the window manager as "normal windows," leading to:

- Invisible blank windows (artifact windows) appearing in the Overview/workspace windows
- Multiple stacked Voquill icons appearing in the Dock (e.g., Plank)
- Unwanted window items appearing in the Alt-Tab/task switcher (depending on WM behavior)

This PR adds window manager hints to Linux overlay windows, making them more like "accessibility windows" and bypassing the taskbar/pager, thus reducing the above interference.

## Context / Background

To avoid accidental click interception by full-screen overlays, Voquill splits the original full-screen overlay into multiple independent overlay windows (pill/toast/agent). In desktop environments like KDE, these overlays are sometimes recognized as manageable windows, even if the window itself is invisible or transparent, thus creating a UI artifact.

## Changes

File: `apps/desktop/src-tauri/src/platform/linux/window.rs`

- Added `configure_overlay_window_manager_hints()` to uniformly set WM attributes for overlays:
- `set_skip_taskbar_hint(true)`
- `set_skip_pager_hint(true)`
- `set_type_hint(WindowTypeHint::Utility)`
- Call this configuration in the following paths to ensure the overlay is correctly marked when showing/configuring non-activating:
- `show_overlay_no_focus()`
- `configure_overlay_non_activating()`

## Why this works

- `skip_taskbar_hint`: Prevents appearance in the taskbar/dock (depending on WM implementation)
- `skip_pager_hint`: Prevents appearance in the pager/overview/workspace window list (KDE) (This is usually more critical)
- `WindowTypeHint::Utility`: Hints that Windows Manager treats it as an auxiliary window rather than a regular application window.

## Testing

- **Manual**:
- Linux (Kubuntu/KDE) desktop launch

- Verification:
- Overview/workspace windows no longer display a blank Voquill artifact window.
- Plank dock still displays multiple stacked Voquill icons, so it's not a perfect solution.
- Overlay still maintains its expected behavior (transparent, always-on-top, click-through, no focus).

## Risk / Notes

- This change only affects the Linux (GTK) platform logic; macOS/Windows are unaffected.
- Window manager hints may behave slightly differently on different Windows Managers; currently, `Utility` is chosen as a relatively conservative type hint.
- If some Windows Managers still cannot completely hide the overlay, further refinement of type hints by label (e.g., toast prefers `Notification`) can be considered as a further convergence solution.
