### PR TITLE
Change ollama API to OpenAI Compatible

### DIFF
--- a/apps/desktop/src/components/settings/ApiKeyList.tsx
+++ b/apps/desktop/src/components/settings/ApiKeyList.tsx
@@ -200,7 +200,7 @@ const AddApiKeyCard = ({ onSave, onCancel, context }: AddApiKeyCardProps) => {
           <MenuItem value="openrouter">OpenRouter</MenuItem>
         )}
         {context === "post-processing" && (
-          <MenuItem value="ollama">Ollama</MenuItem>
+          <MenuItem value="ollama">Ollama/OpenAI Compatible</MenuItem>
         )}
         {context === "post-processing" && (
           <MenuItem value="deepseek">DeepSeek</MenuItem>

--- a/apps/desktop/src/repos/ollama.repo.ts
+++ b/apps/desktop/src/repos/ollama.repo.ts
@@ -29,7 +29,7 @@ export class OllamaRepo extends BaseOllamaRepo {
   }
 
   async getAvailableModels(): Promise<string[]> {
-    const response = await fetch(new URL("/api/tags", this.ollamaUrl).href, {
+    const response = await fetch(new URL("/v1/models", this.ollamaUrl).href, {
       headers: getOllamaHeaders(this.apiKey),
     });
     if (!response.ok) {
@@ -39,15 +39,15 @@ export class OllamaRepo extends BaseOllamaRepo {
     }
 
     const payload = (await response.json()) as {
-      models?: Array<{ name?: string }>;
+      data?: Array<{ id?: string }>;
     };
 
-    if (!payload.models) {
+    if (!payload.data) {
       return [];
     }
 
-    return payload.models
-      .map((model) => (model.name ?? "").trim())
+    return payload.data
+      .map((model) => (model.id ?? "").trim())
       .filter((name): name is string => Boolean(name));
   }
 }


### PR DESCRIPTION
Possible fix for #126 
Change ollama API to OpenAI Compatible, so that it could use other third-party APIs for post-process.
Now Ollama mode use OpenAI compatible format to send a request, which is also supported by ollama server.
Only tested on Windows.