### PR TITLE
fix: separate test connection logic for OpenAI Compatible provider

### DIFF
--- a/apps/desktop/src/components/settings/ApiKeyList.tsx
+++ b/apps/desktop/src/components/settings/ApiKeyList.tsx
@@ -38,6 +38,7 @@ import {
   groqTestIntegration,
   OPENAI_GENERATE_TEXT_MODELS,
   OPENAI_TRANSCRIPTION_MODELS,
+  openaiCompatibleTestIntegration,
   openaiTestIntegration,
   OPENROUTER_FAVORITE_MODELS,
   openrouterTestIntegration,
@@ -403,9 +404,16 @@ const testApiKey = async (
   apiKey: SettingsApiKey,
   context: ApiKeyListContext,
 ): Promise<boolean> => {
-  if (apiKey.provider === "ollama" || apiKey.provider === "openai-compatible") {
+  if (apiKey.provider === "ollama") {
     return ollamaTestIntegration({
       baseUrl: apiKey.baseUrl || OLLAMA_DEFAULT_URL,
+      apiKey: apiKey.keyFull || undefined,
+    });
+  }
+
+  if (apiKey.provider === "openai-compatible") {
+    return openaiCompatibleTestIntegration({
+      baseUrl: apiKey.baseUrl || "http://127.0.0.1:8080",
       apiKey: apiKey.keyFull || undefined,
     });
   }

--- a/packages/voice-ai/src/openai.utils.ts
+++ b/packages/voice-ai/src/openai.utils.ts
@@ -191,6 +191,24 @@ export type OpenAITestIntegrationArgs = {
   apiKey: string;
 };
 
+export type OpenAICompatibleTestIntegrationArgs = {
+  baseUrl: string;
+  apiKey?: string;
+};
+
+export const openaiCompatibleTestIntegration = async ({
+  baseUrl,
+  apiKey,
+}: OpenAICompatibleTestIntegrationArgs): Promise<boolean> => {
+  const client = createClient(apiKey || "dummy", baseUrl);
+
+  // Test connectivity by listing models
+  const response = await client.models.list();
+  
+  // If we get here, the connection is successful
+  return true;
+};
+
 export const openaiTestIntegration = async ({
   apiKey,
 }: OpenAITestIntegrationArgs): Promise<boolean> => {


### PR DESCRIPTION
Fix for #180

The previous code was using ollamaTestIntegration for both providers, which
makes a GET request to the root URL. Ollama's root returns 200 OK, but
LocalAI and other OpenAI-compatible servers expect /v1/* endpoints and
return 500 for root URL requests.

- Add openaiCompatibleTestIntegration function that tests /v1/models endpoint
- Update ApiKeyList to use separate test functions for ollama vs openai-compatible
- Fixes 500 error when testing OpenAI Compatible connections to LocalAI servers


Co-authored-by: KiloCoder <KiloCoder@neurocis.ai>
