### PR TITLE
feat: stream dictation output in real-time when using verbatim mode

### DIFF
--- a/apps/desktop/src/actions/transcribe.actions.ts
+++ b/apps/desktop/src/actions/transcribe.actions.ts
@@ -68,6 +68,7 @@ export type PostProcessInput = {
   rawTranscript: string;
   toneId: Nullable<string>;
   dictationLanguage?: string;
+  precedingContext?: string;
 };
 
 export type PostProcessMetadata = {
@@ -176,6 +177,7 @@ export const postProcessTranscript = async ({
   rawTranscript,
   toneId,
   dictationLanguage: dictationLanguageOverride,
+  precedingContext,
 }: PostProcessInput): Promise<PostProcessResult> => {
   const state = getAppState();
 
@@ -218,6 +220,7 @@ export const postProcessTranscript = async ({
       userName: getMyUserName(state),
       dictationLanguage,
       tone: toneConfig,
+      precedingContext,
     };
     const ppSystem = buildSystemPostProcessingTonePrompt(promptInput);
     const ppPrompt = buildPostProcessingPrompt(promptInput);

--- a/apps/desktop/src/components/root/DictationSideEffects.tsx
+++ b/apps/desktop/src/components/root/DictationSideEffects.tsx
@@ -52,9 +52,10 @@ import {
 import { getLogger } from "../../utils/log.utils";
 import { flashPillTooltip } from "../../utils/overlay.utils";
 import { minutesToMilliseconds } from "../../utils/time.utils";
-import { getToneIdToUse } from "../../utils/tone.utils";
+import { getToneIdToUse, VERBATIM_TONE_ID } from "../../utils/tone.utils";
 import {
   getEffectivePillVisibility,
+  getGenerativePrefs,
   getIsDictationUnlocked,
   getMyPreferredMicrophone,
   getMyPrimaryDictationLanguage,
@@ -417,6 +418,30 @@ export const DictationSideEffects = () => {
           `Transcription prefs: mode=${transcriptPrefs.mode}`,
         );
         const session = createTranscriptionSession(transcriptPrefs);
+        if (
+          session.setInterimResultCallback &&
+          strategy instanceof DictationStrategy
+        ) {
+          const toneId = getToneIdToUse(state, {
+            currentAppToneId: null,
+          });
+          if (toneId === VERBATIM_TONE_ID) {
+            const genPrefs = getGenerativePrefs(state);
+            if (genPrefs.mode !== "none") {
+              strategy.configureStreamingPostProcess(toneId);
+              getLogger().verbose(
+                "Streaming with per-segment post-processing enabled",
+              );
+            } else {
+              getLogger().verbose(
+                "Streaming enabled (raw, no post-processing)",
+              );
+            }
+            session.setInterimResultCallback((segment) => {
+              strategy.handleInterimSegment(segment);
+            });
+          }
+        }
         tryPlayAudioChime("start_recording_clip");
 
         sessionRef.current = session;

--- a/apps/desktop/src/components/styling/ManualStylingRow.tsx
+++ b/apps/desktop/src/components/styling/ManualStylingRow.tsx
@@ -18,6 +18,7 @@ import { produceAppState, useAppStore } from "../../store";
 import {
   getActiveManualToneIds,
   getManuallySelectedToneId,
+  VERBATIM_TONE_ID,
 } from "../../utils/tone.utils";
 import { ListTile } from "../common/ListTile";
 import {
@@ -175,7 +176,18 @@ export const ManualStylingRow = ({ id }: ManualStylingRowProps) => {
           onMouseDown={stopPropagation}
         />
       }
-      title={tone?.name}
+      title={
+        id === VERBATIM_TONE_ID ? (
+          <>
+            {tone?.name}{" "}
+            <span style={{ fontSize: 12 }}>
+              <FormattedMessage defaultMessage="(Streams output in real-time for supported providers)" />
+            </span>
+          </>
+        ) : (
+          tone?.name
+        )
+      }
       subtitle={
         <Typography
           variant="body2"

--- a/apps/desktop/src/sessions/assemblyai-transcription-session.ts
+++ b/apps/desktop/src/sessions/assemblyai-transcription-session.ts
@@ -1,6 +1,7 @@
 import { convertFloat32ToPCM16 } from "@repo/voice-ai";
 import { listen, UnlistenFn } from "@tauri-apps/api/event";
 import {
+  InterimResultCallback,
   StopRecordingResponse,
   TranscriptionSession,
   TranscriptionSessionResult,
@@ -8,6 +9,7 @@ import {
 
 type AssemblyAIStreamingSession = {
   finalize: () => Promise<string>;
+  setInterimCallback: (cb: InterimResultCallback) => void;
   cleanup: () => void;
 };
 
@@ -35,6 +37,11 @@ const startAssemblyAIStreaming = async (
     let sentChunkCount = 0;
     let pendingSampleCount = 0;
     let pendingChunks: Float32Array[] = [];
+    let interimCallback: InterimResultCallback | null = null;
+
+    const setInterimCallback = (cb: InterimResultCallback) => {
+      interimCallback = cb;
+    };
 
     let currentTurn = 0;
     let extra = "";
@@ -250,7 +257,7 @@ const startAssemblyAIStreaming = async (
 
         console.log("[AssemblyAI WebSocket] Session ready, listener attached");
         // Session is ready
-        resolve({ finalize, cleanup });
+        resolve({ finalize, cleanup, setInterimCallback });
       } catch (error) {
         console.error(
           "[AssemblyAI WebSocket] Error setting up listener:",
@@ -272,12 +279,16 @@ const startAssemblyAIStreaming = async (
 
         if (data.type === "Turn" && data.end_of_turn) {
           // Final formatted transcript
+          const segmentText = data.transcript || "";
           finalTranscript +=
-            (finalTranscript ? " " : "") + (data.transcript || "");
+            (finalTranscript ? " " : "") + segmentText;
           console.log(
             "[AssemblyAI WebSocket] Final formatted transcript received:",
             finalTranscript.substring(0, 100),
           );
+          if (interimCallback && segmentText) {
+            interimCallback(segmentText);
+          }
           if (currentTurn === data.turn_order) {
             extra = "";
           }
@@ -312,15 +323,23 @@ const startAssemblyAIStreaming = async (
 export class AssemblyAITranscriptionSession implements TranscriptionSession {
   private session: AssemblyAIStreamingSession | null = null;
   private apiKey: string;
+  private interimCallback: InterimResultCallback | null = null;
 
   constructor(apiKey: string) {
     this.apiKey = apiKey;
+  }
+
+  setInterimResultCallback(callback: InterimResultCallback): void {
+    this.interimCallback = callback;
   }
 
   async onRecordingStart(sampleRate: number): Promise<void> {
     try {
       console.log("[AssemblyAI] Starting streaming session...");
       this.session = await startAssemblyAIStreaming(this.apiKey, sampleRate);
+      if (this.interimCallback) {
+        this.session.setInterimCallback(this.interimCallback);
+      }
       console.log("[AssemblyAI] Streaming session started successfully");
     } catch (error) {
       console.error("[AssemblyAI] Failed to start streaming:", error);

--- a/apps/desktop/src/sessions/deepgram-transcription-session.ts
+++ b/apps/desktop/src/sessions/deepgram-transcription-session.ts
@@ -1,6 +1,7 @@
 import { convertFloat32ToPCM16 } from "@repo/voice-ai";
 import { listen, UnlistenFn } from "@tauri-apps/api/event";
 import {
+  InterimResultCallback,
   StopRecordingResponse,
   TranscriptionSession,
   TranscriptionSessionResult,
@@ -9,6 +10,7 @@ import {
 type DeepgramStreamingSession = {
   finalize: () => Promise<string>;
   cleanup: () => void;
+  setInterimCallback: (cb: InterimResultCallback) => void;
 };
 
 const startDeepgramStreaming = async (
@@ -36,6 +38,11 @@ const startDeepgramStreaming = async (
   let sentChunkCount = 0;
   let pendingSampleCount = 0;
   let pendingChunks: Float32Array[] = [];
+  let interimCallback: InterimResultCallback | null = null;
+
+  const setInterimCallback = (cb: InterimResultCallback) => {
+    interimCallback = cb;
+  };
 
   const getText = () => {
     return (
@@ -234,7 +241,7 @@ const startDeepgramStreaming = async (
       console.log("[Deepgram WebSocket] Connected, flushing buffered audio...");
       flushPendingSamples(false);
       console.log("[Deepgram WebSocket] Session ready");
-      resolve({ finalize, cleanup });
+      resolve({ finalize, cleanup, setInterimCallback });
     };
 
     ws.onmessage = (event) => {
@@ -259,6 +266,9 @@ const startDeepgramStreaming = async (
               "[Deepgram WebSocket] Final transcript received:",
               finalTranscript.substring(0, 100),
             );
+            if (interimCallback) {
+              interimCallback(transcript);
+            }
             if (speechFinal && isFinalized) {
               completeFinalize();
             }
@@ -298,9 +308,14 @@ export class DeepgramTranscriptionSession implements TranscriptionSession {
   private session: DeepgramStreamingSession | null = null;
   private startupPromise: Promise<void> | null = null;
   private apiKey: string;
+  private interimCallback: InterimResultCallback | null = null;
 
   constructor(apiKey: string) {
     this.apiKey = apiKey;
+  }
+
+  setInterimResultCallback(callback: InterimResultCallback): void {
+    this.interimCallback = callback;
   }
 
   async onRecordingStart(sampleRate: number): Promise<void> {
@@ -308,6 +323,9 @@ export class DeepgramTranscriptionSession implements TranscriptionSession {
       try {
         console.log("[Deepgram] Starting streaming session...");
         this.session = await startDeepgramStreaming(this.apiKey, sampleRate);
+        if (this.interimCallback) {
+          this.session.setInterimCallback(this.interimCallback);
+        }
         console.log("[Deepgram] Streaming session started successfully");
       } catch (error) {
         console.error("[Deepgram] Failed to start streaming:", error);

--- a/apps/desktop/src/sessions/elevenlabs-transcription-session.ts
+++ b/apps/desktop/src/sessions/elevenlabs-transcription-session.ts
@@ -1,6 +1,7 @@
 import { convertFloat32ToBase64PCM16 } from "@repo/voice-ai";
 import { listen, UnlistenFn } from "@tauri-apps/api/event";
 import {
+  InterimResultCallback,
   StopRecordingResponse,
   TranscriptionSession,
   TranscriptionSessionResult,
@@ -9,6 +10,7 @@ import {
 type ElevenLabsStreamingSession = {
   finalize: () => Promise<string>;
   cleanup: () => void;
+  setInterimCallback: (cb: InterimResultCallback) => void;
 };
 
 const ELEVENLABS_WS_URL = "wss://api.elevenlabs.io/v1/speech-to-text/realtime";
@@ -91,6 +93,11 @@ const startElevenLabsStreaming = async (
     let sentChunkCount = 0;
     let pendingSampleCount = 0;
     let pendingChunks: Float32Array[] = [];
+    let interimCallback: InterimResultCallback | null = null;
+
+    const setInterimCallback = (cb: InterimResultCallback) => {
+      interimCallback = cb;
+    };
 
     const getText = () => {
       return (
@@ -311,7 +318,7 @@ const startElevenLabsStreaming = async (
         );
 
         console.log("[ElevenLabs WebSocket] Session ready, listener attached");
-        resolve({ finalize, cleanup });
+        resolve({ finalize, cleanup, setInterimCallback });
       } catch (error) {
         console.error(
           "[ElevenLabs WebSocket] Error setting up listener:",
@@ -333,12 +340,16 @@ const startElevenLabsStreaming = async (
         );
 
         if (messageType === "committed_transcript") {
-          finalTranscript += (finalTranscript ? " " : "") + (data.text || "");
+          const segmentText = data.text || "";
+          finalTranscript += (finalTranscript ? " " : "") + segmentText;
           partialTranscript = "";
           console.log(
             "[ElevenLabs WebSocket] Committed transcript received:",
             finalTranscript.substring(0, 100),
           );
+          if (interimCallback && segmentText) {
+            interimCallback(segmentText);
+          }
           if (isFinalized) {
             completeFinalize();
           }
@@ -373,15 +384,23 @@ const startElevenLabsStreaming = async (
 export class ElevenLabsTranscriptionSession implements TranscriptionSession {
   private session: ElevenLabsStreamingSession | null = null;
   private apiKey: string;
+  private interimCallback: InterimResultCallback | null = null;
 
   constructor(apiKey: string) {
     this.apiKey = apiKey;
+  }
+
+  setInterimResultCallback(callback: InterimResultCallback): void {
+    this.interimCallback = callback;
   }
 
   async onRecordingStart(sampleRate: number): Promise<void> {
     try {
       console.log("[ElevenLabs] Starting streaming session...");
       this.session = await startElevenLabsStreaming(this.apiKey, sampleRate);
+      if (this.interimCallback) {
+        this.session.setInterimCallback(this.interimCallback);
+      }
       console.log("[ElevenLabs] Streaming session started successfully");
     } catch (error) {
       console.error("[ElevenLabs] Failed to start streaming:", error);

--- a/apps/desktop/src/strategies/dictation.strategy.ts
+++ b/apps/desktop/src/strategies/dictation.strategy.ts
@@ -23,8 +23,67 @@ import {
 import { BaseStrategy } from "./base.strategy";
 
 export class DictationStrategy extends BaseStrategy {
+  private streamedSegmentCount = 0;
+  private streamedProcessedText = "";
+  private streamingPostProcess = false;
+  private streamingToneId: string | null = null;
+  private pasteQueue: Promise<void> = Promise.resolve();
+
   shouldStoreTranscript(): boolean {
     return true;
+  }
+
+  get hasStreamedSegments(): boolean {
+    return this.streamedSegmentCount > 0;
+  }
+
+  configureStreamingPostProcess(toneId: string | null): void {
+    this.streamingPostProcess = true;
+    this.streamingToneId = toneId;
+  }
+
+  handleInterimSegment(segment: string): void {
+    const state = getAppState();
+    const replacementRules = Object.values(state.termById)
+      .filter((term) => term.isReplacement)
+      .map((term) => ({
+        sourceValue: term.sourceValue,
+        destinationValue: term.destinationValue,
+      }));
+
+    const afterReplacements = applyReplacements(segment, replacementRules);
+    const sanitized = applySymbolConversions(afterReplacements);
+
+    if (!sanitized) return;
+
+    const isFirst = this.streamedSegmentCount === 0;
+    this.streamedSegmentCount++;
+
+    this.pasteQueue = this.pasteQueue.then(async () => {
+      let text = sanitized;
+
+      if (this.streamingPostProcess) {
+        try {
+          const result = await postProcessTranscript({
+            rawTranscript: sanitized,
+            toneId: this.streamingToneId,
+            precedingContext: this.streamedProcessedText || undefined,
+          });
+          text = result.transcript;
+        } catch (error) {
+          getLogger().error(`Failed to post-process segment: ${error}`);
+        }
+      }
+
+      const textToPaste = (isFirst ? "" : " ") + text;
+      this.streamedProcessedText += (isFirst ? "" : " ") + text;
+
+      try {
+        await invoke<void>("paste", { text: textToPaste, keybind: null });
+      } catch (error) {
+        getLogger().error(`Failed to paste interim segment: ${error}`);
+      }
+    });
   }
 
   validateAvailability(): Nullable<StrategyValidationError> {
@@ -86,7 +145,18 @@ export class DictationStrategy extends BaseStrategy {
       );
       sanitizedTranscript = applySymbolConversions(afterReplacements);
 
-      if (processedTranscript && sessionPostProcessMetadata) {
+      if (this.hasStreamedSegments) {
+        await this.pasteQueue;
+        try {
+          await invoke<void>("paste", { text: " ", keybind: null });
+        } catch {
+          // Non-critical trailing space
+        }
+        transcript = this.streamedProcessedText || sanitizedTranscript;
+        getLogger().info(
+          `Streaming dictation complete (${this.streamedSegmentCount} segments, postProcessed=${this.streamingPostProcess})`,
+        );
+      } else if (processedTranscript && sessionPostProcessMetadata) {
         const afterProcessedReplacements = applyReplacements(
           processedTranscript,
           replacementRules,
@@ -104,7 +174,7 @@ export class DictationStrategy extends BaseStrategy {
         postProcessWarnings = result.warnings;
       }
 
-      if (transcript) {
+      if (transcript && !this.hasStreamedSegments) {
         await new Promise<void>((resolve) => setTimeout(resolve, 20));
         try {
           const keybind = currentApp?.pasteKeybind ?? null;
@@ -112,7 +182,6 @@ export class DictationStrategy extends BaseStrategy {
             `Pasting transcript (${transcript.length} chars, keybind=${keybind ?? "default"})`,
           );
 
-          // Add a space to the end so you don't have to press space before your next dictation
           const textToPaste = transcript.trim() + " ";
           await invoke<void>("paste", { text: textToPaste, keybind });
 

--- a/apps/desktop/src/types/transcription-session.types.ts
+++ b/apps/desktop/src/types/transcription-session.types.ts
@@ -21,8 +21,11 @@ export type TranscriptionSessionFinalizeOptions = {
   a11yInfo?: unknown;
 };
 
+export type InterimResultCallback = (segment: string) => void;
+
 export interface TranscriptionSession {
   onRecordingStart(sampleRate: number): Promise<void>;
+  setInterimResultCallback?(callback: InterimResultCallback): void;
   finalize(
     audio: StopRecordingResponse,
     options?: TranscriptionSessionFinalizeOptions,

--- a/apps/desktop/src/utils/prompt.utils.ts
+++ b/apps/desktop/src/utils/prompt.utils.ts
@@ -88,6 +88,7 @@ export type PostProcessingPromptInput = {
   userName: string;
   dictationLanguage: string;
   tone: ToneConfig;
+  precedingContext?: string;
 };
 
 const buildPostProcessingTemplateVars = (
@@ -104,13 +105,22 @@ const buildPostProcessingTemplateVars = (
 export const buildSystemPostProcessingTonePrompt = (
   input: PostProcessingPromptInput,
 ): string => {
+  let systemPrompt: string;
   if (input.tone.kind === "template" && input.tone.systemPromptTemplate) {
-    return applyTemplateVars(
+    systemPrompt = applyTemplateVars(
       input.tone.systemPromptTemplate,
       buildPostProcessingTemplateVars(input),
     );
+  } else {
+    systemPrompt =
+      "You are a transcript rewriting assistant. You modify the style and tone of the transcript while keeping the subject matter the same. Your response MUST be in JSON format with ONLY a single field 'processedTranscription' that contains the rewritten transcript.";
   }
-  return "You are a transcript rewriting assistant. You modify the style and tone of the transcript while keeping the subject matter the same. Your response MUST be in JSON format with ONLY a single field 'processedTranscription' that contains the rewritten transcript.";
+
+  if (input.precedingContext) {
+    systemPrompt += `\n\nThis is a continuation of an ongoing dictation. The following text has already been processed and output. Use it ONLY for context to ensure proper punctuation, capitalization, and flow. Do NOT repeat or include it in your response. Process ONLY the new transcript provided.\n\nAlready processed:\n${input.precedingContext}`;
+  }
+
+  return systemPrompt;
 };
 
 type ReplacementRule = {


### PR DESCRIPTION
# PR: Stream Dictation Output in Verbatim Mode

**Branch:** `feat/streaming-verbatim`
**Target:** `josiahsrc/voquill` `main`
**Title:** feat: stream dictation output in real-time when using verbatim mode

---

## Summary

- When the verbatim writing style is selected, dictation output is streamed sentence-by-sentence as the STT provider finalizes segments, instead of waiting until the recording stops
- When post-processing is enabled alongside verbatim, each segment is run through the LLM before pasting (with preceding context for proper punctuation/flow). When post-processing is off, raw STT output streams directly
- No new settings, database migrations, or UI toggles needed - streaming activates automatically when the user selects the verbatim style
- Works with all streaming STT providers (Deepgram, AssemblyAI, ElevenLabs)
- Non-streaming fallback (batch paste at end) still applies for all other writing styles and non-streaming providers (local Whisper, Azure, batch)

## How it works

Streaming STT providers already send finalized transcript segments during recording. This PR adds an `InterimResultCallback` interface to transcription sessions. When the active style is verbatim at recording start, the callback is wired up to paste each finalized segment immediately via the existing paste infrastructure.

If post-processing is configured (`mode !== "none"`), each segment is passed through `postProcessTranscript()` before pasting. Previously processed text is included as context in the system prompt so the LLM can maintain proper punctuation, capitalization, and flow across segments.

At stop time, if segments were already streamed, the strategy skips the normal batch paste and just appends a trailing space.

## Why verbatim?

Per discussion with @josiahsrc - tying streaming to verbatim mode is cleaner than a separate toggle because:
1. Verbatim is the natural fit for "raw output as you speak"
2. Most users use post-processing, so streaming by default would skip their preferred AI cleanup
3. No new settings to configure - selecting verbatim style enables it automatically

## Changes

### Transcription sessions
- `transcription-session.types.ts` - Added `InterimResultCallback` type and optional `setInterimResultCallback` method to `TranscriptionSession` interface
- `deepgram-transcription-session.ts` - Implements interim callback, fires on each finalized transcript segment
- `assemblyai-transcription-session.ts` - Implements interim callback for final transcript events
- `elevenlabs-transcription-session.ts` - Implements interim callback for finalized segments

### Strategy
- `dictation.strategy.ts` - Added `handleInterimSegment()` for real-time paste with sequential queue, optional per-segment post-processing with preceding context, `hasStreamedSegments` flag to skip batch paste at end, replacement rules and symbol conversions applied to each segment

### Post-processing context
- `transcribe.actions.ts` - Added optional `precedingContext` field to `PostProcessInput`
- `prompt.utils.ts` - Added `precedingContext` to `PostProcessingPromptInput`, injected into system prompt for continuity across segments

### Wiring
- `DictationSideEffects.tsx` - At recording start, resolves the current style; if verbatim, wires the interim callback to the strategy. If post-processing is also enabled, configures per-segment post-processing

### UI
- `ManualStylingRow.tsx` -  Adds "(Streams output in real-time for supported providers)" note to Verbatim style in the style picker

## Test plan

- [ ] Build and run the desktop app
- [ ] Select the "Verbatim" writing style
- [ ] **Post-processing OFF**: Start dictating - verify text appears sentence-by-sentence while still speaking with minimal latency
- [ ] **Post-processing ON**: Start dictating - verify text appears sentence-by-sentence with per-segment LLM processing (slightly longer per-sentence delay, visible in API dashboard)
- [ ] Stop dictating - verify a trailing space is added and no duplicate paste occurs
- [ ] Switch to a different writing style (e.g. Polished, Email)
- [ ] Dictate - verify normal batch behavior (text appears after stop, with AI post-processing)
- [ ] Test with Deepgram, AssemblyAI, and ElevenLabs providers
- [ ] Verify replacement rules and symbol conversions are applied to streamed segments
- [ ] Verify streaming note appears next to Verbatim in the style picker

---

*Branch: `feat/streaming-verbatim` on `jsandai/voquill`*