### PR TITLE
feat(desktop): add opt-in paste last dictation hotkey

### DIFF
--- a/apps/desktop/src/actions/paste-last-transcription.actions.ts
+++ b/apps/desktop/src/actions/paste-last-transcription.actions.ts
@@ -1,0 +1,96 @@
+import { invoke } from "@tauri-apps/api/core";
+import { getTranscriptionRepo } from "../repos";
+import { getAppState } from "../store";
+import { getIntl } from "../i18n";
+import { normalizeAppTargetId } from "../utils/apptarget.utils";
+import { getLogger } from "../utils/log.utils";
+import {
+  findLatestPasteableTranscript,
+  getLatestPasteableTranscriptFromState,
+  resolveReplayPasteKeybind,
+} from "../utils/paste-last-transcription.utils";
+import { insertLocalTranscriptOutput } from "../utils/output-routing.utils";
+import { showErrorSnackbar, showSnackbar } from "./app.actions";
+
+const REPLAY_TRANSCRIPTION_FALLBACK_LIMIT = 20;
+
+type CurrentAppInfoResponse = {
+  appName?: string | null;
+};
+
+const getCurrentAppTargetIdForReplay = async (): Promise<string | null> => {
+  const state = getAppState();
+  if (
+    !state.supportsAppDetection ||
+    state.supportsPasteKeybinds !== "per-app"
+  ) {
+    return null;
+  }
+
+  try {
+    const appInfo = await invoke<CurrentAppInfoResponse>(
+      "get_current_app_info",
+    );
+    const appName = appInfo.appName?.trim() ?? "";
+    return appName ? normalizeAppTargetId(appName) : null;
+  } catch (error) {
+    getLogger().verbose(
+      `Failed to resolve current app for replay paste: ${error}`,
+    );
+    return null;
+  }
+};
+
+const getLatestSavedTranscript = async (): Promise<string | null> => {
+  const fromState = getLatestPasteableTranscriptFromState(getAppState());
+  if (fromState) {
+    return fromState;
+  }
+
+  const transcriptions = await getTranscriptionRepo().listTranscriptions({
+    limit: REPLAY_TRANSCRIPTION_FALLBACK_LIMIT,
+  });
+  return findLatestPasteableTranscript(transcriptions);
+};
+
+export const pasteLastTranscription = async (): Promise<void> => {
+  const intl = getIntl();
+
+  try {
+    const transcript = await getLatestSavedTranscript();
+    if (!transcript) {
+      showSnackbar(
+        intl.formatMessage({
+          defaultMessage: "No transcription to insert.",
+        }),
+      );
+      return;
+    }
+
+    const currentAppId = await getCurrentAppTargetIdForReplay();
+    const state = getAppState();
+    const currentApp = currentAppId
+      ? (state.appTargetById[currentAppId] ?? null)
+      : null;
+    const keybind = resolveReplayPasteKeybind({
+      supportsPasteKeybinds: state.supportsPasteKeybinds,
+      userPasteKeybind: state.userPrefs?.pasteKeybind,
+      appTargetPasteKeybind: currentApp?.pasteKeybind,
+    });
+
+    await insertLocalTranscriptOutput(`${transcript} `, keybind);
+    showSnackbar(
+      intl.formatMessage({
+        defaultMessage: "Last transcription inserted.",
+      }),
+      { mode: "success" },
+    );
+  } catch (error) {
+    getLogger().error(`Failed to paste last transcription: ${error}`);
+    showErrorSnackbar(
+      intl.formatMessage({
+        defaultMessage: "Unable to insert last transcription.",
+      }),
+    );
+  }
+};

--- a/apps/desktop/src/components/root/AppSideEffects.tsx
+++ b/apps/desktop/src/components/root/AppSideEffects.tsx
@@ -16,6 +16,7 @@ import { useIntl } from "react-intl";
 import { combineLatest, from, Observable, of } from "rxjs";
 import { showErrorSnackbar, showSnackbar } from "../../actions/app.actions";
 import { loadPairedRemoteDevices } from "../../actions/paired-remote-device.actions";
+import { pasteLastTranscription } from "../../actions/paste-last-transcription.actions";
 import { openUpgradePlanDialog } from "../../actions/pricing.actions";
 import {
   refreshRemoteReceiverStatus,
@@ -61,7 +62,11 @@ import {
 } from "../../utils/enterprise.utils";
 import { getIsDevMode } from "../../utils/env.utils";
 import { createId } from "../../utils/id.utils";
-import { ADD_TO_DICTIONARY_HOTKEY } from "../../utils/keyboard.utils";
+import {
+  ADD_TO_DICTIONARY_HOTKEY,
+  getIsPasteLastTranscriptionHotkeyEnabled,
+  PASTE_LAST_TRANSCRIPTION_HOTKEY,
+} from "../../utils/keyboard.utils";
 import { getLogger, initLogging } from "../../utils/log.utils";
 import { sendPillFlashMessage } from "../../utils/overlay.utils";
 import { isPermissionAuthorized } from "../../utils/permission.utils";
@@ -145,6 +150,9 @@ export const AppSideEffects = () => {
   const prefs = useAppStore((state) => getMyUserPreferences(state));
   const keyPermAuthorized = useAppStore((state) =>
     isPermissionAuthorized(getRec(state.permissions, "accessibility")?.state),
+  );
+  const pasteLastTranscriptionHotkeyEnabled = useAppStore(
+    getIsPasteLastTranscriptionHotkeyEnabled,
   );
 
   const hotkeyStrategy = useAppStore((state) => state.hotkeyStrategy);
@@ -585,6 +593,12 @@ export const AppSideEffects = () => {
     actionName: ADD_TO_DICTIONARY_HOTKEY,
     isDisabled: false,
     onFire: handleAddToDictionary,
+  });
+
+  useHotkeyFire({
+    actionName: PASTE_LAST_TRANSCRIPTION_HOTKEY,
+    isDisabled: !pasteLastTranscriptionHotkeyEnabled,
+    onFire: pasteLastTranscription,
   });
 
   // You cannot refresh the page in Tauri, here's a hotkey to help with that

--- a/apps/desktop/src/components/settings/HotkeySetting.tsx
+++ b/apps/desktop/src/components/settings/HotkeySetting.tsx
@@ -22,6 +22,8 @@ export type HotkeySettingProps = {
   buttonSize?: "small" | "medium";
   enabled?: boolean;
   onEnabledChange?: (enabled: boolean) => void;
+  suggestedKeys?: string[];
+  deleteOnDisable?: boolean;
 };
 
 const areCombosEqual = (a: string[], b: string[]) =>
@@ -40,6 +42,8 @@ export const HotkeySetting = ({
   buttonSize = "small",
   enabled,
   onEnabledChange,
+  suggestedKeys,
+  deleteOnDisable = false,
 }: HotkeySettingProps) => {
   const hasEnabledToggle = enabled !== undefined;
   const isEnabled = enabled ?? true;
@@ -102,26 +106,51 @@ export const HotkeySetting = ({
     }
   };
 
-  const handleDeleteHotkey = async (id: string) => {
+  const deleteHotkeys = async (hotkeysToDelete: Hotkey[]) => {
+    if (hotkeysToDelete.length === 0) {
+      return;
+    }
+
+    const deletedIds = new Set(hotkeysToDelete.map((hotkey) => hotkey.id));
+    let updatedState = false;
     try {
       produceAppState((draft) => {
-        delete draft.hotkeyById[id];
+        for (const id of deletedIds) {
+          delete draft.hotkeyById[id];
+        }
         draft.settings.hotkeyIds = draft.settings.hotkeyIds.filter(
-          (hid) => hid !== id,
+          (id) => !deletedIds.has(id),
         );
       });
-      await getHotkeyRepo().deleteHotkey(id);
-      await syncHotkeyCombosToNative();
+      updatedState = true;
+      await Promise.all(
+        hotkeysToDelete.map((hotkey) =>
+          getHotkeyRepo().deleteHotkey(hotkey.id),
+        ),
+      );
     } catch (error) {
       console.error("Failed to delete hotkey", error);
       showErrorSnackbar("Failed to delete hotkey. Please try again.");
+    } finally {
+      if (updatedState) {
+        await syncHotkeyCombosToNative();
+      }
     }
+  };
+
+  const handleDeleteHotkey = async (id: string) => {
+    await deleteHotkeys(hotkeys.filter((hotkey) => hotkey.id === id));
+  };
+
+  const deleteHotkeysForAction = async () => {
+    await deleteHotkeys(hotkeys);
   };
 
   const [primaryHotkey, ...additionalHotkeys] = hotkeys;
   const showDefaultAsPrimary = !primaryHotkey && defaultCombos.length > 0;
   const primaryValue =
-    primaryHotkey?.keys ?? (showDefaultAsPrimary ? defaultCombos[0] : []);
+    primaryHotkey?.keys ??
+    (showDefaultAsPrimary ? defaultCombos[0] : (suggestedKeys ?? []));
   const isPrimaryUsingDefault =
     primaryHotkey != null &&
     defaultCombos.some((combo) => areCombosEqual(combo, primaryHotkey.keys));
@@ -152,14 +181,24 @@ export const HotkeySetting = ({
     const newEnabled = event.target.checked;
     onEnabledChange?.(newEnabled);
 
-    // When enabling, set up a default hotkey if none exists
-    if (newEnabled && !primaryHotkey && defaultCombos.length > 0) {
-      void saveKey(undefined, defaultCombos[0]);
+    if (!newEnabled) {
+      if (deleteOnDisable) {
+        void deleteHotkeysForAction();
+      }
+      return;
+    }
+
+    const keys = defaultCombos[0] ?? suggestedKeys;
+    if (!primaryHotkey && keys && keys.length > 0) {
+      void saveKey(undefined, keys);
     }
   };
 
   const handleDisable = () => {
     onEnabledChange?.(false);
+    if (deleteOnDisable) {
+      void deleteHotkeysForAction();
+    }
   };
 
   return (

--- a/apps/desktop/src/components/settings/ShortcutsDialog.tsx
+++ b/apps/desktop/src/components/settings/ShortcutsDialog.tsx
@@ -17,13 +17,19 @@ import {
   AGENT_DICTATE_HOTKEY,
   CANCEL_TRANSCRIPTION_HOTKEY,
   DICTATE_HOTKEY,
+  getIsPasteLastTranscriptionHotkeyEnabled,
   OPEN_CHAT_HOTKEY,
+  PASTE_LAST_TRANSCRIPTION_HOTKEY,
+  PASTE_LAST_TRANSCRIPTION_SUGGESTED_KEYS,
   SWITCH_WRITING_STYLE_HOTKEY,
 } from "../../utils/keyboard.utils";
 import { HotkeySetting } from "./HotkeySetting";
 
 export const ShortcutsDialog = () => {
   const isAssistantModeEnabled = useAppStore(getIsAssistantModeEnabled);
+  const pasteLastTranscriptionHotkeyEnabled = useAppStore(
+    getIsPasteLastTranscriptionHotkeyEnabled,
+  );
   const { open, hotkeysStatus, isManualStyling } = useAppStore((state) => ({
     open: state.settings.shortcutsDialogOpen,
     hotkeysStatus: state.settings.hotkeysStatus,
@@ -74,6 +80,16 @@ export const ShortcutsDialog = () => {
             <FormattedMessage defaultMessage="Cancel the current dictation or agent session." />
           }
           actionName={CANCEL_TRANSCRIPTION_HOTKEY}
+        />
+        <HotkeySetting
+          title={<FormattedMessage defaultMessage="Paste last dictation" />}
+          description={
+            <FormattedMessage defaultMessage="Insert your most recent saved dictation into the focused text field." />
+          }
+          actionName={PASTE_LAST_TRANSCRIPTION_HOTKEY}
+          enabled={pasteLastTranscriptionHotkeyEnabled}
+          suggestedKeys={PASTE_LAST_TRANSCRIPTION_SUGGESTED_KEYS}
+          deleteOnDisable
         />
         <HotkeySetting
           title={<FormattedMessage defaultMessage="Open chat" />}

--- a/apps/desktop/src/utils/keyboard.utils.test.ts
+++ b/apps/desktop/src/utils/keyboard.utils.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import {
+  getDefaultHotkeyCombosForAction,
+  getIsPasteLastTranscriptionHotkeyEnabled,
+  PASTE_LAST_TRANSCRIPTION_HOTKEY,
+  PASTE_LAST_TRANSCRIPTION_SUGGESTED_KEYS,
+} from "./keyboard.utils";
+
+describe("paste last transcription hotkey", () => {
+  it("does not register a default hotkey", () => {
+    expect(
+      getDefaultHotkeyCombosForAction(PASTE_LAST_TRANSCRIPTION_HOTKEY),
+    ).toEqual([]);
+  });
+
+  it("keeps Alt+Shift+Z as the opt-in suggested hotkey", () => {
+    expect(PASTE_LAST_TRANSCRIPTION_SUGGESTED_KEYS).toEqual([
+      "Alt",
+      "ShiftLeft",
+      "KeyZ",
+    ]);
+  });
+
+  it("is disabled until a user-saved hotkey exists", () => {
+    expect(getIsPasteLastTranscriptionHotkeyEnabled({ hotkeyById: {} })).toBe(
+      false,
+    );
+    expect(
+      getIsPasteLastTranscriptionHotkeyEnabled({
+        hotkeyById: {
+          empty: {
+            id: "empty",
+            actionName: PASTE_LAST_TRANSCRIPTION_HOTKEY,
+            keys: [],
+          },
+        },
+      }),
+    ).toBe(false);
+  });
+
+  it("is enabled when a user-saved hotkey exists", () => {
+    expect(
+      getIsPasteLastTranscriptionHotkeyEnabled({
+        hotkeyById: {
+          replay: {
+            id: "replay",
+            actionName: PASTE_LAST_TRANSCRIPTION_HOTKEY,
+            keys: PASTE_LAST_TRANSCRIPTION_SUGGESTED_KEYS,
+          },
+        },
+      }),
+    ).toBe(true);
+  });
+});

--- a/apps/desktop/src/utils/keyboard.utils.ts
+++ b/apps/desktop/src/utils/keyboard.utils.ts
@@ -11,7 +11,14 @@ export const SWITCH_WRITING_STYLE_HOTKEY = "switch-writing-style";
 export const CANCEL_TRANSCRIPTION_HOTKEY = "cancel-transcription";
 export const OPEN_CHAT_HOTKEY = "open-chat";
 export const ADD_TO_DICTIONARY_HOTKEY = "add-to-dictionary";
+export const PASTE_LAST_TRANSCRIPTION_HOTKEY = "paste-last-transcription";
 export const ADDITIONAL_LANGUAGE_HOTKEY_PREFIX = "additional-language:";
+
+export const PASTE_LAST_TRANSCRIPTION_SUGGESTED_KEYS = [
+  "Alt",
+  "ShiftLeft",
+  "KeyZ",
+];
 
 type CompositorBinding = {
   actionName: string;
@@ -23,6 +30,7 @@ const COMPOSITOR_TRIGGER_ACTIONS = [
   AGENT_DICTATE_HOTKEY,
   SWITCH_WRITING_STYLE_HOTKEY,
   CANCEL_TRANSCRIPTION_HOTKEY,
+  PASTE_LAST_TRANSCRIPTION_HOTKEY,
 ];
 
 export const getAdditionalLanguageActionName = (language: string): string =>
@@ -144,6 +152,21 @@ export const getHotkeyCombosForAction = (
   }
 
   return getDefaultHotkeyCombosForAction(actionName);
+};
+
+export const getHasUserHotkeyForAction = (
+  state: Pick<AppState, "hotkeyById">,
+  actionName: string,
+): boolean => {
+  return Object.values(state.hotkeyById).some(
+    (hotkey) => hotkey.actionName === actionName && hotkey.keys.length > 0,
+  );
+};
+
+export const getIsPasteLastTranscriptionHotkeyEnabled = (
+  state: Pick<AppState, "hotkeyById">,
+): boolean => {
+  return getHasUserHotkeyForAction(state, PASTE_LAST_TRANSCRIPTION_HOTKEY);
 };
 
 export type AdditionalLanguageEntry = {

--- a/apps/desktop/src/utils/paste-last-transcription.utils.test.ts
+++ b/apps/desktop/src/utils/paste-last-transcription.utils.test.ts
@@ -1,0 +1,89 @@
+import type { Transcription } from "@voquill/types";
+import { describe, expect, it } from "vitest";
+import {
+  findLatestPasteableTranscript,
+  getLatestPasteableTranscriptFromState,
+  getPasteableTranscript,
+  resolveReplayPasteKeybind,
+} from "./paste-last-transcription.utils";
+
+const transcription = (id: string, transcript: string): Transcription => ({
+  id,
+  transcript,
+  createdAt: "2026-04-08T00:00:00.000Z",
+  createdByUserId: "user",
+  isDeleted: false,
+});
+
+describe("paste last transcription utils", () => {
+  it("trims usable transcripts", () => {
+    expect(getPasteableTranscript(transcription("one", "  hello  "))).toBe(
+      "hello",
+    );
+  });
+
+  it("skips empty and failed transcripts", () => {
+    expect(getPasteableTranscript(transcription("empty", "  "))).toBeNull();
+    expect(
+      getPasteableTranscript(transcription("failed", "[Transcription Failed]")),
+    ).toBeNull();
+  });
+
+  it("finds the newest pasteable transcript from ordered candidates", () => {
+    expect(
+      findLatestPasteableTranscript([
+        transcription("empty", ""),
+        transcription("failed", "[Transcription Failed]"),
+        transcription("latest", "use this"),
+        transcription("older", "not this"),
+      ]),
+    ).toBe("use this");
+  });
+
+  it("finds the newest pasteable transcript from state order", () => {
+    expect(
+      getLatestPasteableTranscriptFromState({
+        transcriptionById: {
+          older: transcription("older", "old value"),
+          latest: transcription("latest", "new value"),
+        },
+        transcriptions: {
+          transcriptionIds: ["latest", "missing", "older"],
+        },
+      }),
+    ).toBe("new value");
+  });
+
+  it("resolves replay paste keybind precedence", () => {
+    expect(
+      resolveReplayPasteKeybind({
+        supportsPasteKeybinds: "disabled",
+        userPasteKeybind: "Ctrl+V",
+        appTargetPasteKeybind: "Ctrl+Shift+V",
+      }),
+    ).toBeNull();
+
+    expect(
+      resolveReplayPasteKeybind({
+        supportsPasteKeybinds: "global",
+        userPasteKeybind: "Ctrl+V",
+        appTargetPasteKeybind: "Ctrl+Shift+V",
+      }),
+    ).toBe("Ctrl+V");
+
+    expect(
+      resolveReplayPasteKeybind({
+        supportsPasteKeybinds: "per-app",
+        userPasteKeybind: "Ctrl+V",
+        appTargetPasteKeybind: "Ctrl+Shift+V",
+      }),
+    ).toBe("Ctrl+Shift+V");
+
+    expect(
+      resolveReplayPasteKeybind({
+        supportsPasteKeybinds: "per-app",
+        userPasteKeybind: "Ctrl+V",
+      }),
+    ).toBe("Ctrl+V");
+  });
+});

--- a/apps/desktop/src/utils/paste-last-transcription.utils.ts
+++ b/apps/desktop/src/utils/paste-last-transcription.utils.ts
@@ -1,0 +1,68 @@
+import type { Transcription } from "@voquill/types";
+import type { PasteKeybindSupport } from "../state/app.state";
+
+const FAILED_TRANSCRIPTION_PLACEHOLDER = "[Transcription Failed]";
+
+export type TranscriptionStateLike = {
+  transcriptionById: Record<string, Transcription | undefined>;
+  transcriptions: {
+    transcriptionIds: string[];
+  };
+};
+
+export type ResolveReplayPasteKeybindArgs = {
+  supportsPasteKeybinds: PasteKeybindSupport;
+  userPasteKeybind?: string | null;
+  appTargetPasteKeybind?: string | null;
+};
+
+export const getPasteableTranscript = (
+  transcription: Transcription | null | undefined,
+): string | null => {
+  const transcript = transcription?.transcript.trim() ?? "";
+  if (!transcript || transcript === FAILED_TRANSCRIPTION_PLACEHOLDER) {
+    return null;
+  }
+
+  return transcript;
+};
+
+export const findLatestPasteableTranscript = (
+  transcriptions: Array<Transcription | null | undefined>,
+): string | null => {
+  for (const transcription of transcriptions) {
+    const transcript = getPasteableTranscript(transcription);
+    if (transcript) {
+      return transcript;
+    }
+  }
+
+  return null;
+};
+
+export const getLatestPasteableTranscriptFromState = (
+  state: TranscriptionStateLike,
+): string | null => {
+  return findLatestPasteableTranscript(
+    state.transcriptions.transcriptionIds.map(
+      (id) => state.transcriptionById[id],
+    ),
+  );
+};
+
+export const resolveReplayPasteKeybind = ({
+  supportsPasteKeybinds,
+  userPasteKeybind,
+  appTargetPasteKeybind,
+}: ResolveReplayPasteKeybindArgs): string | null => {
+  if (supportsPasteKeybinds === "disabled") {
+    return null;
+  }
+
+  const userKeybind = userPasteKeybind ?? null;
+  if (supportsPasteKeybinds === "global") {
+    return userKeybind;
+  }
+
+  return appTargetPasteKeybind ?? userKeybind;
+};


### PR DESCRIPTION
## What changed?

- Adds an opt-in desktop shortcut for pasting the most recent saved dictation into the focused text field.
- Keeps the shortcut disabled by default; users must enable it in Keyboard shortcuts, where Alt+Shift+Z is suggested.
- Reuses existing transcription history, hotkey sync, Wayland bridge, and native paste paths instead of adding a separate OS-specific paste implementation.
- Bypasses remote output for replay so the command pastes locally on the current machine.

## How is it tested?

- [x] Automated tests: corepack.cmd pnpm --filter desktop exec vitest run src/utils/keyboard.utils.test.ts src/utils/paste-last-transcription.utils.test.ts
- [x] Code inspection: corepack.cmd pnpm --filter desktop exec tsc --noEmit; targeted Prettier check; git diff --check
- [ ] Manual verification: needs maintainer/local pass on macOS, Windows, Linux X11, and Linux Wayland

Note: full desktop lint was not completed locally because this machine is using Node v22.14.0, while oxlint's TypeScript config loading requires Node ^20.19.0 or >=22.18.0. The repo .nvmrc requests Node 24.

 I really like this open source product and use it daily. I wanted to contribute this as a small quality-of-life improvement for Voquill. The shortcut is intentionally opt-in and disabled by default, so it should not change
  the existing experience for users who do not want it. Thanks for maintaining this project.