### PR TITLE
copy to clipboard on paste fail

### DIFF
--- a/apps/desktop/src-tauri/src/app.rs
+++ b/apps/desktop/src-tauri/src/app.rs
@@ -204,6 +204,7 @@ pub fn build() -> tauri::Builder<tauri::Wry> {
             crate::commands::surface_main_window,
             crate::commands::set_pill_window_size,
             crate::commands::paste,
+            crate::commands::copy_to_clipboard,
             crate::commands::transcription_create,
             crate::commands::transcription_list,
             crate::commands::transcription_delete,

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -17,6 +17,14 @@ use sqlx::Row;
 
 use crate::platform::input::paste_text_into_focused_field as platform_paste_text;
 
+#[derive(serde::Serialize, Clone, Debug)]
+#[serde(rename_all = "camelCase")]
+pub enum PasteMethod {
+    Accessibility,
+    Clipboard,
+    NoTarget,
+}
+
 #[derive(serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct StopRecordingResponse {
@@ -1260,7 +1268,16 @@ pub fn sync_native_pill_assistant(app: AppHandle, payload: String) {
 }
 
 #[tauri::command]
-pub async fn paste(text: String, keybind: Option<String>) -> Result<(), String> {
+pub fn copy_to_clipboard(text: String) -> Result<(), String> {
+    let mut clipboard =
+        arboard::Clipboard::new().map_err(|e| format!("clipboard unavailable: {e}"))?;
+    clipboard
+        .set_text(text)
+        .map_err(|e| format!("failed to set clipboard: {e}"))
+}
+
+#[tauri::command]
+pub async fn paste(text: String, keybind: Option<String>) -> Result<PasteMethod, String> {
     let join_result = tauri::async_runtime::spawn_blocking(move || {
         platform_paste_text(&text, keybind.as_deref())
     })

--- a/apps/desktop/src-tauri/src/platform/linux/input.rs
+++ b/apps/desktop/src-tauri/src/platform/linux/input.rs
@@ -1,9 +1,9 @@
 pub(crate) fn paste_text_into_focused_field(
     text: &str,
     keybind: Option<&str>,
-) -> Result<(), String> {
+) -> Result<crate::commands::PasteMethod, String> {
     if text.trim().is_empty() {
-        return Ok(());
+        return Ok(crate::commands::PasteMethod::Clipboard);
     }
 
     let override_text = std::env::var("VOQUILL_DEBUG_PASTE_TEXT").ok();
@@ -15,8 +15,9 @@ pub(crate) fn paste_text_into_focused_field(
 
     if super::detect::is_wayland() {
         log::info!("Wayland session detected");
-        super::wl::input::paste_text(target, keybind)
+        super::wl::input::paste_text(target, keybind)?;
     } else {
-        super::x11::input::paste_text(target, keybind)
+        super::x11::input::paste_text(target, keybind)?;
     }
+    Ok(crate::commands::PasteMethod::Clipboard)
 }

--- a/apps/desktop/src-tauri/src/platform/macos/accessibility.rs
+++ b/apps/desktop/src-tauri/src/platform/macos/accessibility.rs
@@ -800,7 +800,7 @@ unsafe fn gather_screen_context(element: CFTypeRef, depth: usize) -> String {
     texts.join("\n")
 }
 
-pub fn insert_text_at_cursor(text: &str) -> Result<(), String> {
+pub(crate) fn insert_text_at_cursor(text: &str) -> Result<TextInsertOutcome, String> {
     let text = text.to_string();
     run_on_main_thread(move || {
         catch_unwind(AssertUnwindSafe(move || unsafe {
@@ -810,10 +810,18 @@ pub fn insert_text_at_cursor(text: &str) -> Result<(), String> {
     })
 }
 
-unsafe fn insert_text_at_cursor_impl(text: &str) -> Result<(), String> {
+#[derive(Debug)]
+pub(crate) enum TextInsertOutcome {
+    Inserted,
+    RequiresClipboardPaste(String),
+    NoTarget(String),
+}
+
+unsafe fn insert_text_at_cursor_impl(text: &str) -> Result<TextInsertOutcome, String> {
     let ax_focused_ui_element = CFString::new("AXFocusedUIElement");
     let ax_selected_text = CFString::new("AXSelectedText");
     let ax_value = CFString::new("AXValue");
+    let ax_role = CFString::new("AXRole");
 
     let system_wide = AXUIElementCreateSystemWide();
     if system_wide.is_null() {
@@ -830,12 +838,26 @@ unsafe fn insert_text_at_cursor_impl(text: &str) -> Result<(), String> {
     CFRelease(system_wide);
 
     if result != AX_ERROR_SUCCESS || focused_element.is_null() {
-        return Err("no focused element".to_string());
+        return Ok(TextInsertOutcome::NoTarget("no focused element".to_string()));
+    }
+
+    let role = get_string_attribute(focused_element, ax_role.as_concrete_TypeRef());
+    if !matches!(
+        role.as_deref(),
+        Some("AXTextField" | "AXTextArea" | "AXSearchField" | "AXComboBox")
+    ) {
+        CFRelease(focused_element);
+        return Ok(TextInsertOutcome::NoTarget(format!(
+            "focused element role is not text-input capable: {}",
+            role.unwrap_or_else(|| "unknown".to_string())
+        )));
     }
 
     if is_element_inside_web_area(focused_element) {
         CFRelease(focused_element);
-        return Err("focused element is inside AXWebArea".to_string());
+        return Ok(TextInsertOutcome::RequiresClipboardPaste(
+            "focused text input is inside AXWebArea".to_string(),
+        ));
     }
 
     // Check if the focused element actually supports setting AXSelectedText
@@ -848,7 +870,9 @@ unsafe fn insert_text_at_cursor_impl(text: &str) -> Result<(), String> {
 
     if settable_result != AX_ERROR_SUCCESS || !settable {
         CFRelease(focused_element);
-        return Err("AXSelectedText is not settable on focused element".to_string());
+        return Ok(TextInsertOutcome::RequiresClipboardPaste(
+            "AXSelectedText is not settable on focused element".to_string(),
+        ));
     }
 
     // Snapshot the field value before inserting so we can verify
@@ -863,7 +887,9 @@ unsafe fn insert_text_at_cursor_impl(text: &str) -> Result<(), String> {
 
     if set_result != AX_ERROR_SUCCESS {
         CFRelease(focused_element);
-        return Err(format!("AXUIElementSetAttributeValue failed: {set_result}"));
+        return Ok(TextInsertOutcome::RequiresClipboardPaste(format!(
+            "AXUIElementSetAttributeValue failed: {set_result}"
+        )));
     }
 
     // Verify: if we can read the value and it didn't change, the insert silently failed
@@ -872,11 +898,13 @@ unsafe fn insert_text_at_cursor_impl(text: &str) -> Result<(), String> {
 
     if let (Some(before), Some(after)) = (&value_before, &value_after) {
         if before == after {
-            return Err("AXSelectedText accepted but field value unchanged".to_string());
+            return Ok(TextInsertOutcome::RequiresClipboardPaste(
+                "AXSelectedText accepted but field value unchanged".to_string(),
+            ));
         }
     }
 
-    Ok(())
+    Ok(TextInsertOutcome::Inserted)
 }
 
 pub fn get_selected_text() -> Option<String> {
@@ -901,4 +929,3 @@ pub fn get_selected_text() -> Option<String> {
 
     selected.filter(|s| !s.is_empty())
 }
-

--- a/apps/desktop/src-tauri/src/platform/macos/input.rs
+++ b/apps/desktop/src-tauri/src/platform/macos/input.rs
@@ -5,51 +5,58 @@ use std::{thread, time::Duration};
 use super::accessibility;
 
 const KEY_C: CGKeyCode = 8;
-const KEY_SPACE: CGKeyCode = 49;
 const KEY_V: CGKeyCode = 9;
 
 pub(crate) fn paste_text_into_focused_field(
     text: &str,
     _keybind: Option<&str>,
-) -> Result<(), String> {
+) -> Result<crate::commands::PasteMethod, String> {
     if text.trim().is_empty() {
-        return Ok(());
+        return Ok(crate::commands::PasteMethod::Accessibility);
     }
 
     match accessibility::insert_text_at_cursor(text) {
-        Ok(()) => Ok(()),
+        Ok(accessibility::TextInsertOutcome::Inserted) => {
+            Ok(crate::commands::PasteMethod::Accessibility)
+        }
+        Ok(accessibility::TextInsertOutcome::RequiresClipboardPaste(reason)) => {
+            log::warn!(
+                "Accessibility insert failed ({reason}), falling back to clipboard paste"
+            );
+            paste_via_clipboard(text)?;
+            Ok(crate::commands::PasteMethod::Clipboard)
+        }
+        Ok(accessibility::TextInsertOutcome::NoTarget(reason)) => {
+            log::warn!("No text field target: {reason}");
+            Ok(crate::commands::PasteMethod::NoTarget)
+        }
         Err(err) => {
-            log::warn!("Accessibility insert failed ({err}), falling back to clipboard paste");
-            paste_via_clipboard(text)
+            log::error!("Accessibility insert failed unexpectedly: {err}");
+            if text.trim().is_empty() {
+                Ok(crate::commands::PasteMethod::Accessibility)
+            } else {
+                paste_via_clipboard(text)?;
+                Ok(crate::commands::PasteMethod::Clipboard)
+            }
         }
     }
 }
 
 fn paste_via_clipboard(text: &str) -> Result<(), String> {
-    let trimmed_text = text.trim_end_matches(' ');
-    let trailing_spaces = text.len() - trimmed_text.len();
+    let mut clipboard =
+        arboard::Clipboard::new().map_err(|err| format!("clipboard unavailable: {err}"))?;
+    let previous = crate::platform::SavedClipboard::save(&mut clipboard);
+    clipboard
+        .set_text(text.to_string())
+        .map_err(|err| format!("failed to store clipboard text: {err}"))?;
 
-    if !trimmed_text.is_empty() {
-        let mut clipboard =
-            arboard::Clipboard::new().map_err(|err| format!("clipboard unavailable: {err}"))?;
-        let previous = crate::platform::SavedClipboard::save(&mut clipboard);
-        clipboard
-            .set_text(trimmed_text.to_string())
-            .map_err(|err| format!("failed to store clipboard text: {err}"))?;
+    thread::sleep(Duration::from_millis(50));
+    simulate_cmd_v()?;
 
-        thread::sleep(Duration::from_millis(50));
-        simulate_cmd_v()?;
-
-        thread::spawn(move || {
-            thread::sleep(Duration::from_millis(800));
-            previous.restore();
-        });
-    }
-
-    for _ in 0..trailing_spaces {
-        thread::sleep(Duration::from_millis(10));
-        simulate_keypress(KEY_SPACE, CGEventFlags::empty())?;
-    }
+    thread::spawn(move || {
+        thread::sleep(Duration::from_millis(800));
+        previous.restore();
+    });
 
     Ok(())
 }

--- a/apps/desktop/src-tauri/src/platform/windows/input.rs
+++ b/apps/desktop/src-tauri/src/platform/windows/input.rs
@@ -19,9 +19,9 @@ pub struct WindowTargetInfo {
 pub(crate) fn paste_text_into_focused_field(
     text: &str,
     keybind: Option<&str>,
-) -> Result<(), String> {
+) -> Result<crate::commands::PasteMethod, String> {
     if text.trim().is_empty() {
-        return Ok(());
+        return Ok(crate::commands::PasteMethod::Clipboard);
     }
 
     let override_text = env::var("VOQUILL_DEBUG_PASTE_TEXT").ok();
@@ -39,7 +39,8 @@ pub(crate) fn paste_text_into_focused_field(
         thread::sleep(Duration::from_millis(50));
         enigo.key_sequence(target);
         Ok(())
-    })
+    })?;
+    Ok(crate::commands::PasteMethod::Clipboard)
 }
 
 fn is_console_window() -> bool {

--- a/apps/desktop/src/utils/output-routing.utils.ts
+++ b/apps/desktop/src/utils/output-routing.utils.ts
@@ -3,9 +3,14 @@ import type {
   RouteTranscriptOutputArgs,
   RouteTranscriptOutputResult,
 } from "@voquill/types";
+import { showToast } from "../actions/toast.actions";
+import { getIntl } from "../i18n/intl";
 import { getAppState } from "../store";
+import { getLogger } from "./log.utils";
 import { sanitizeIndentation } from "./string.utils";
 import { getMyUserPreferences } from "./user.utils";
+
+type PasteMethod = "accessibility" | "clipboard" | "noTarget";
 
 export const routeTranscriptOutput = async (
   args: RouteTranscriptOutputArgs,
@@ -55,8 +60,31 @@ export const insertLocalTranscriptOutput = async (
   text: string,
   keybind: string | null,
 ): Promise<void> => {
-  await invoke<void>("paste", {
-    text: sanitizeIndentation(text),
-    keybind,
-  });
+  const sanitized = sanitizeIndentation(text);
+  if (!sanitized.trim()) return;
+
+  let method: PasteMethod;
+  try {
+    method = await invoke<PasteMethod>("paste", {
+      text: sanitized,
+      keybind,
+    });
+  } catch (error) {
+    getLogger().error(`Paste command failed: ${error}`);
+    method = "noTarget";
+  }
+
+  if (method !== "noTarget") return;
+
+  try {
+    await invoke<void>("copy_to_clipboard", { text: sanitized });
+    await showToast({
+      message: getIntl().formatMessage({
+        defaultMessage: "Text copied to clipboard",
+      }),
+      toastType: "info",
+    });
+  } catch (error) {
+    getLogger().error(`Clipboard fallback failed: ${error}`);
+  }
 };


### PR DESCRIPTION
## What changed?

Added copy-to-clipboard functionality to the Voquill application. This includes:
- New `copy_to_clipboard` command that copies text to the system clipboard
- Enhanced clipboard integration with proper error handling
- Accessibility improvements for better text insertion on macOS
- Platform-specific paste method handling for Linux (Wayland/X11)

<!-- Demo video/screenshots -->

## How is it tested?

- [x] Automated tests
- [x] Manual verification
- [ ] Code inspection
