### PR TITLE
Replace Firebase JSON keys with Workload Identity Federation

### DIFF
--- a/.github/workflows/build-web.yml
+++ b/.github/workflows/build-web.yml
@@ -11,6 +11,7 @@ on:
 permissions:
   checks: write
   pull-requests: write
+  id-token: write
 
 jobs:
   build:
@@ -39,11 +40,16 @@ jobs:
           PUBLIC_MIXPANEL_TOKEN: ${{ secrets.MIXPANEL_TOKEN_DEV }}
         run: pnpm exec turbo run build --filter=web...
 
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.WIF_PROVIDER }}
+          service_account: ${{ secrets.WIF_SERVICE_ACCOUNT }}
+
       - name: Deploy preview channel
         uses: FirebaseExtended/action-hosting-deploy@v0
         with:
           repoToken: ${{ secrets.GITHUB_TOKEN }}
-          firebaseServiceAccount: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_VOQUILL_PROD }}
           projectId: voquill-prod
           expires: 7d
           entryPoint: apps/web

--- a/.github/workflows/build-web.yml
+++ b/.github/workflows/build-web.yml
@@ -47,9 +47,5 @@ jobs:
           service_account: ${{ secrets.WIF_SERVICE_ACCOUNT }}
 
       - name: Deploy preview channel
-        uses: FirebaseExtended/action-hosting-deploy@v0
-        with:
-          repoToken: ${{ secrets.GITHUB_TOKEN }}
-          projectId: voquill-prod
-          expires: 7d
-          entryPoint: apps/web
+        working-directory: apps/web
+        run: npx firebase-tools@latest hosting:channel:deploy pr-${{ github.event.pull_request.number }} --expires 7d --project voquill-prod --non-interactive --config firebase.json

--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -10,6 +10,10 @@ on:
       - ".github/workflows/release-docs.yml"
   workflow_dispatch:
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   deploy:
     name: Build and deploy docs site
@@ -35,34 +39,15 @@ jobs:
       - name: Build docs workspace
         run: pnpm exec turbo run build --filter=docs...
 
-      - name: Configure Firebase credentials
-        env:
-          FIREBASE_ADMIN_BASE64: ${{ secrets.FIREBASE_ADMIN_BASE64 }}
-        run: |
-          set -euo pipefail
-          if [[ -z "${FIREBASE_ADMIN_BASE64:-}" ]]; then
-            echo "FIREBASE_ADMIN_BASE64 GitHub secret is not configured." >&2
-            exit 1
-          fi
-
-          CREDENTIALS_PATH="${HOME}/firebase-admin.json"
-          echo "${FIREBASE_ADMIN_BASE64}" | base64 --decode > "${CREDENTIALS_PATH}"
-          chmod 600 "${CREDENTIALS_PATH}"
-          echo "GOOGLE_APPLICATION_CREDENTIALS=${CREDENTIALS_PATH}" >> "${GITHUB_ENV}"
-
-          PROJECT_ID="$(jq -r '.project_id // empty' "${CREDENTIALS_PATH}")"
-          if [[ -z "${PROJECT_ID}" ]]; then
-            echo "Unable to read project_id from decoded Firebase credentials." >&2
-            exit 1
-          fi
-          echo "FIREBASE_PROJECT_ID=${PROJECT_ID}" >> "${GITHUB_ENV}"
-          echo "Config complete!"
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.WIF_PROVIDER }}
+          service_account: ${{ secrets.WIF_SERVICE_ACCOUNT }}
 
       - name: Deploy to Firebase Hosting
         working-directory: apps/docs
-        env:
-          FIREBASE_PROJECT_ID: ${{ env.FIREBASE_PROJECT_ID }}
         run: |
           set -euo pipefail
-          echo "Deploying docs hosting for project: ${FIREBASE_PROJECT_ID}"
-          npx firebase-tools@latest deploy --only hosting:voquill-docs --project "${FIREBASE_PROJECT_ID}" --non-interactive --force --config firebase.json
+          echo "Deploying docs hosting for project: voquill-prod"
+          npx firebase-tools@latest deploy --only hosting:voquill-docs --project voquill-prod --non-interactive --force --config firebase.json

--- a/.github/workflows/release-web.yml
+++ b/.github/workflows/release-web.yml
@@ -9,6 +9,10 @@ on:
       - ".github/workflows/release-web.yml"
   workflow_dispatch:
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   deploy:
     name: Build and deploy web app
@@ -36,34 +40,15 @@ jobs:
           PUBLIC_MIXPANEL_TOKEN: ${{ secrets.MIXPANEL_TOKEN_PROD }}
         run: pnpm exec turbo run build --filter=web...
 
-      - name: Configure Firebase credentials
-        env:
-          FIREBASE_ADMIN_BASE64: ${{ secrets.FIREBASE_ADMIN_BASE64 }}
-        run: |
-          set -euo pipefail
-          if [[ -z "${FIREBASE_ADMIN_BASE64:-}" ]]; then
-            echo "FIREBASE_ADMIN_BASE64 GitHub secret is not configured." >&2
-            exit 1
-          fi
-
-          CREDENTIALS_PATH="${HOME}/firebase-admin.json"
-          echo "${FIREBASE_ADMIN_BASE64}" | base64 --decode > "${CREDENTIALS_PATH}"
-          chmod 600 "${CREDENTIALS_PATH}"
-          echo "GOOGLE_APPLICATION_CREDENTIALS=${CREDENTIALS_PATH}" >> "${GITHUB_ENV}"
-
-          PROJECT_ID="$(jq -r '.project_id // empty' "${CREDENTIALS_PATH}")"
-          if [[ -z "${PROJECT_ID}" ]]; then
-            echo "Unable to read project_id from decoded Firebase credentials." >&2
-            exit 1
-          fi
-          echo "FIREBASE_PROJECT_ID=${PROJECT_ID}" >> "${GITHUB_ENV}"
-          echo "Config complete!"
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.WIF_PROVIDER }}
+          service_account: ${{ secrets.WIF_SERVICE_ACCOUNT }}
 
       - name: Deploy to Firebase Hosting
         working-directory: apps/web
-        env:
-          FIREBASE_PROJECT_ID: ${{ env.FIREBASE_PROJECT_ID }}
         run: |
           set -euo pipefail
-          echo "Deploying hosting for project: ${FIREBASE_PROJECT_ID}"
-          npx firebase-tools@latest deploy --only hosting --project "${FIREBASE_PROJECT_ID}" --non-interactive --force --config firebase.json
+          echo "Deploying hosting for project: voquill-prod"
+          npx firebase-tools@latest deploy --only hosting --project voquill-prod --non-interactive --force --config firebase.json

--- a/docs/wif-migration-todo.md
+++ b/docs/wif-migration-todo.md
@@ -1,0 +1,84 @@
+# Workload Identity Federation Migration - Manual Steps
+
+SOC 2 compliance requires eliminating user-managed service account JSON keys.
+Two branches (`fix-deployments`) contain the code changes. This doc covers
+the manual GCP/GitHub steps needed to complete the migration.
+
+---
+
+## 1. Set up WIF on `voquill-prod` (for voquill/voquill repo)
+
+The zoetis repo already has WIF configured. The voquill repo does not.
+
+```bash
+# Create Workload Identity Pool
+gcloud iam workload-identity-pools create "github-actions" \
+  --project="voquill-prod" \
+  --location="global" \
+  --display-name="GitHub Actions"
+
+# Create OIDC Provider for GitHub
+gcloud iam workload-identity-pools providers create-oidc "github" \
+  --project="voquill-prod" \
+  --location="global" \
+  --workload-identity-pool="github-actions" \
+  --display-name="GitHub" \
+  --attribute-mapping="google.subject=assertion.sub,attribute.actor=assertion.actor,attribute.repository=assertion.repository,attribute.repository_owner=assertion.repository_owner" \
+  --attribute-condition="assertion.repository_owner == 'voquill'" \
+  --issuer-uri="https://token.actions.githubusercontent.com"
+
+# Get project number (save this — you need it for the next command and for GitHub secrets)
+gcloud projects describe voquill-prod --format="value(projectNumber)"
+
+# Allow firebase-adminsdk SA to be impersonated via WIF
+# Replace PROJECT_NUMBER with the output from above
+gcloud iam service-accounts add-iam-policy-binding \
+  "firebase-adminsdk-fbsvc@voquill-prod.iam.gserviceaccount.com" \
+  --project="voquill-prod" \
+  --role="roles/iam.workloadIdentityUser" \
+  --member="principalSet://iam.googleapis.com/projects/PROJECT_NUMBER/locations/global/workloadIdentityPools/github-actions/attribute.repository/voquill/voquill"
+```
+
+## 2. Add GitHub secrets to `voquill/voquill`
+
+Replace `PROJECT_NUMBER` with the value from step 1.
+
+| Secret | Value |
+|--------|-------|
+| `WIF_PROVIDER` | `projects/PROJECT_NUMBER/locations/global/workloadIdentityPools/github-actions/providers/github` |
+| `WIF_SERVICE_ACCOUNT` | `firebase-adminsdk-fbsvc@voquill-prod.iam.gserviceaccount.com` |
+
+Add these as both repo-level secrets AND to the `web` environment (used by release-docs and release-web workflows).
+
+## 3. Merge the `fix-deployments` branches
+
+- [ ] `voquill/voquill` — merge `fix-deployments` into `main`
+- [ ] `voquill/zoetis` — merge `fix-deployments` into `main`
+
+## 4. Verify deployments work
+
+- [ ] Trigger a PR to `main` on voquill touching `apps/web/` — verify `build-web.yml` preview deploy succeeds
+- [ ] Merge a change to `apps/web/` — verify `release-web.yml` deploys
+- [ ] Merge a change to `apps/docs/` — verify `release-docs.yml` deploys
+
+## 5. Delete old JSON keys from GCP
+
+Once deployments are verified, delete the user-managed keys from these service accounts
+in the GCP console (IAM & Admin > Service Accounts > click account > Keys tab):
+
+- [ ] `firebase-adminsdk-fbsvc@voquill-dev.iam.gserviceaccount.com` (voquill-dev project) — not used anywhere, just delete
+- [ ] `firebase-adminsdk-fbsvc@voquill-prod.iam.gserviceaccount.com` (voquill-prod project) — delete after step 4 passes
+- [ ] `github-actions@voquill-dev.iam.gserviceaccount.com` (voquill-dev project) — created by zoetis setup script, unused
+- [ ] `github-actions@voquill-prod.iam.gserviceaccount.com` (voquill-prod project) — created by zoetis setup script, unused
+
+## 6. Delete old GitHub secrets
+
+- [ ] `voquill/voquill`: delete `FIREBASE_ADMIN_BASE64`
+- [ ] `voquill/voquill`: delete `FIREBASE_SERVICE_ACCOUNT_VOQUILL_PROD`
+- [ ] `voquill/zoetis`: delete `FIREBASE_SERVICE_ACCOUNT_DEV`
+- [ ] `voquill/zoetis`: delete `FIREBASE_SERVICE_ACCOUNT_PROD`
+
+## 7. Confirm OneLeet alerts clear
+
+After the keys are deleted, the OneLeet alerts for "GCP user-managed service account keys"
+should resolve within their next scan cycle.


### PR DESCRIPTION
## Summary
- Replaces user-managed service account JSON keys with Workload Identity Federation (OIDC) in all three Firebase deploy workflows (`release-docs`, `release-web`, `build-web`)
- Eliminates long-lived credentials to resolve SOC 2 compliance alerts from OneLeet
- Adds migration checklist doc for remaining manual cleanup steps

## Test plan
- [ ] Trigger a PR touching `apps/web/` to verify `build-web.yml` preview deploy works
- [ ] Merge a change to `apps/web/` to verify `release-web.yml` deploys
- [ ] Merge a change to `apps/docs/` to verify `release-docs.yml` deploys
- [ ] After verification, delete old JSON keys and GitHub secrets per `docs/wif-migration-todo.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated deployment workflows to use modern workload identity authentication and streamlined deploy commands for the production site.
* **Documentation**
  * Added migration guide with step-by-step actions to complete the workload identity migration and post-migration cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->