### PR TITLE
Fix pasting

### DIFF
--- a/apps/desktop/src-tauri/src/app.rs
+++ b/apps/desktop/src-tauri/src/app.rs
@@ -278,6 +278,7 @@ pub fn build() -> tauri::Builder<tauri::Wry> {
             crate::commands::get_text_field_info,
             crate::commands::get_screen_context,
             crate::commands::get_selected_text,
+            crate::commands::check_focused_paste_target,
             crate::commands::read_enterprise_target,
             crate::commands::run_terminal_command,
             crate::commands::get_hotkey_strategy,

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -51,6 +51,14 @@ pub struct ScreenContextInfo {
     pub screen_context: Option<String>,
 }
 
+#[derive(Debug, Clone, Copy, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PasteTargetState {
+    Editable,
+    NotEditable,
+    Unknown,
+}
+
 #[derive(serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AppTargetUpsertArgs {
@@ -1422,6 +1430,19 @@ pub async fn get_selected_text() -> Result<Option<String>, String> {
     )
     .await
     .map_err(|_| "get_selected_text timed out".to_string())?
+    .map_err(|err| err.to_string())
+}
+
+#[tauri::command]
+pub async fn check_focused_paste_target() -> Result<PasteTargetState, String> {
+    tokio::time::timeout(
+        std::time::Duration::from_secs(1),
+        tauri::async_runtime::spawn_blocking(
+            crate::platform::accessibility::check_focused_paste_target,
+        ),
+    )
+    .await
+    .map_err(|_| "check_focused_paste_target timed out".to_string())?
     .map_err(|err| err.to_string())
 }
 

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -17,14 +17,6 @@ use sqlx::Row;
 
 use crate::platform::input::paste_text_into_focused_field as platform_paste_text;
 
-#[derive(serde::Serialize, Clone, Debug)]
-#[serde(rename_all = "camelCase")]
-pub enum PasteMethod {
-    Accessibility,
-    Clipboard,
-    NoTarget,
-}
-
 #[derive(serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct StopRecordingResponse {
@@ -1277,7 +1269,7 @@ pub fn copy_to_clipboard(text: String) -> Result<(), String> {
 }
 
 #[tauri::command]
-pub async fn paste(text: String, keybind: Option<String>) -> Result<PasteMethod, String> {
+pub async fn paste(text: String, keybind: Option<String>) -> Result<(), String> {
     let join_result = tauri::async_runtime::spawn_blocking(move || {
         platform_paste_text(&text, keybind.as_deref())
     })

--- a/apps/desktop/src-tauri/src/platform/linux/accessibility.rs
+++ b/apps/desktop/src-tauri/src/platform/linux/accessibility.rs
@@ -18,6 +18,10 @@ pub fn get_screen_context() -> ScreenContextInfo {
     }
 }
 
+pub fn check_focused_paste_target() -> crate::commands::PasteTargetState {
+    crate::commands::PasteTargetState::Unknown
+}
+
 pub fn get_selected_text() -> Option<String> {
     if super::detect::is_wayland() {
         super::wl::accessibility::get_selected_text()

--- a/apps/desktop/src-tauri/src/platform/linux/input.rs
+++ b/apps/desktop/src-tauri/src/platform/linux/input.rs
@@ -1,9 +1,9 @@
 pub(crate) fn paste_text_into_focused_field(
     text: &str,
     keybind: Option<&str>,
-) -> Result<crate::commands::PasteMethod, String> {
+) -> Result<(), String> {
     if text.trim().is_empty() {
-        return Ok(crate::commands::PasteMethod::Clipboard);
+        return Ok(());
     }
 
     let override_text = std::env::var("VOQUILL_DEBUG_PASTE_TEXT").ok();
@@ -15,9 +15,8 @@ pub(crate) fn paste_text_into_focused_field(
 
     if super::detect::is_wayland() {
         log::info!("Wayland session detected");
-        super::wl::input::paste_text(target, keybind)?;
+        super::wl::input::paste_text(target, keybind)
     } else {
-        super::x11::input::paste_text(target, keybind)?;
+        super::x11::input::paste_text(target, keybind)
     }
-    Ok(crate::commands::PasteMethod::Clipboard)
 }

--- a/apps/desktop/src-tauri/src/platform/macos/accessibility.rs
+++ b/apps/desktop/src-tauri/src/platform/macos/accessibility.rs
@@ -879,6 +879,86 @@ unsafe fn insert_text_at_cursor_impl(text: &str) -> Result<(), String> {
     Ok(())
 }
 
+pub fn check_focused_paste_target() -> crate::commands::PasteTargetState {
+    use crate::commands::PasteTargetState;
+    catch_unwind(AssertUnwindSafe(|| unsafe { check_focused_paste_target_impl() }))
+        .unwrap_or(PasteTargetState::Unknown)
+}
+
+unsafe fn check_focused_paste_target_impl() -> crate::commands::PasteTargetState {
+    use crate::commands::PasteTargetState;
+
+    let ax_focused_ui_element = CFString::new("AXFocusedUIElement");
+    let ax_role = CFString::new("AXRole");
+    let ax_value = CFString::new("AXValue");
+    let ax_selected_text = CFString::new("AXSelectedText");
+
+    let system_wide = AXUIElementCreateSystemWide();
+    if system_wide.is_null() {
+        return PasteTargetState::Unknown;
+    }
+
+    let mut focused: CFTypeRef = ptr::null();
+    let result = AXUIElementCopyAttributeValue(
+        system_wide,
+        ax_focused_ui_element.as_concrete_TypeRef(),
+        &mut focused,
+    );
+    CFRelease(system_wide);
+
+    if result != AX_ERROR_SUCCESS {
+        return PasteTargetState::Unknown;
+    }
+    if focused.is_null() {
+        return PasteTargetState::NotEditable;
+    }
+
+    let role = get_string_attribute(focused, ax_role.as_concrete_TypeRef());
+
+    let editable_roles = [
+        "AXTextField",
+        "AXTextArea",
+        "AXComboBox",
+        "AXSearchField",
+    ];
+    if let Some(ref r) = role {
+        if editable_roles.iter().any(|er| er == r) {
+            CFRelease(focused);
+            return PasteTargetState::Editable;
+        }
+    }
+
+    if is_element_inside_web_area(focused) {
+        CFRelease(focused);
+        return PasteTargetState::Unknown;
+    }
+
+    let mut settable = false;
+    let settable_result = AXUIElementIsAttributeSettable(
+        focused,
+        ax_selected_text.as_concrete_TypeRef(),
+        &mut settable,
+    );
+    if settable_result == AX_ERROR_SUCCESS && settable {
+        CFRelease(focused);
+        return PasteTargetState::Editable;
+    }
+
+    settable = false;
+    let value_settable_result = AXUIElementIsAttributeSettable(
+        focused,
+        ax_value.as_concrete_TypeRef(),
+        &mut settable,
+    );
+    CFRelease(focused);
+
+    if value_settable_result == AX_ERROR_SUCCESS && settable {
+        return PasteTargetState::Editable;
+    }
+
+    PasteTargetState::NotEditable
+}
+
 pub fn get_selected_text() -> Option<String> {
     use std::{thread, time::Duration};
 

--- a/apps/desktop/src-tauri/src/platform/macos/accessibility.rs
+++ b/apps/desktop/src-tauri/src/platform/macos/accessibility.rs
@@ -800,7 +800,7 @@ unsafe fn gather_screen_context(element: CFTypeRef, depth: usize) -> String {
     texts.join("\n")
 }
 
-pub(crate) fn insert_text_at_cursor(text: &str) -> Result<TextInsertOutcome, String> {
+pub fn insert_text_at_cursor(text: &str) -> Result<(), String> {
     let text = text.to_string();
     run_on_main_thread(move || {
         catch_unwind(AssertUnwindSafe(move || unsafe {
@@ -810,18 +810,10 @@ pub(crate) fn insert_text_at_cursor(text: &str) -> Result<TextInsertOutcome, Str
     })
 }
 
-#[derive(Debug)]
-pub(crate) enum TextInsertOutcome {
-    Inserted,
-    RequiresClipboardPaste(String),
-    NoTarget(String),
-}
-
-unsafe fn insert_text_at_cursor_impl(text: &str) -> Result<TextInsertOutcome, String> {
+unsafe fn insert_text_at_cursor_impl(text: &str) -> Result<(), String> {
     let ax_focused_ui_element = CFString::new("AXFocusedUIElement");
     let ax_selected_text = CFString::new("AXSelectedText");
     let ax_value = CFString::new("AXValue");
-    let ax_role = CFString::new("AXRole");
 
     let system_wide = AXUIElementCreateSystemWide();
     if system_wide.is_null() {
@@ -838,25 +830,15 @@ unsafe fn insert_text_at_cursor_impl(text: &str) -> Result<TextInsertOutcome, St
     CFRelease(system_wide);
 
     if result != AX_ERROR_SUCCESS || focused_element.is_null() {
-        return Ok(TextInsertOutcome::NoTarget("no focused element".to_string()));
-    }
-
-    let role = get_string_attribute(focused_element, ax_role.as_concrete_TypeRef());
-    if is_non_text_role(role.as_deref().unwrap_or("unknown")) {
-        CFRelease(focused_element);
-        return Ok(TextInsertOutcome::NoTarget(format!(
-            "focused element role is not text-input capable: {}",
-            role.unwrap_or_else(|| "unknown".to_string())
-        )));
+        return Err("no focused element".to_string());
     }
 
     if is_element_inside_web_area(focused_element) {
         CFRelease(focused_element);
-        return Ok(TextInsertOutcome::RequiresClipboardPaste(
-            "focused text input is inside AXWebArea".to_string(),
-        ));
+        return Err("focused element is inside AXWebArea".to_string());
     }
 
+    // Check if the focused element actually supports setting AXSelectedText
     let mut settable = false;
     let settable_result = AXUIElementIsAttributeSettable(
         focused_element,
@@ -866,11 +848,10 @@ unsafe fn insert_text_at_cursor_impl(text: &str) -> Result<TextInsertOutcome, St
 
     if settable_result != AX_ERROR_SUCCESS || !settable {
         CFRelease(focused_element);
-        return Ok(TextInsertOutcome::RequiresClipboardPaste(
-            "AXSelectedText is not settable on focused element".to_string(),
-        ));
+        return Err("AXSelectedText is not settable on focused element".to_string());
     }
 
+    // Snapshot the field value before inserting so we can verify
     let value_before = get_string_attribute(focused_element, ax_value.as_concrete_TypeRef());
 
     let cf_text = CFString::new(text);
@@ -882,113 +863,20 @@ unsafe fn insert_text_at_cursor_impl(text: &str) -> Result<TextInsertOutcome, St
 
     if set_result != AX_ERROR_SUCCESS {
         CFRelease(focused_element);
-        return Ok(TextInsertOutcome::RequiresClipboardPaste(format!(
-            "AXUIElementSetAttributeValue failed: {set_result}"
-        )));
+        return Err(format!("AXUIElementSetAttributeValue failed: {set_result}"));
     }
 
+    // Verify: if we can read the value and it didn't change, the insert silently failed
     let value_after = get_string_attribute(focused_element, ax_value.as_concrete_TypeRef());
     CFRelease(focused_element);
 
     if let (Some(before), Some(after)) = (&value_before, &value_after) {
         if before == after {
-            return Ok(TextInsertOutcome::RequiresClipboardPaste(
-                "AXSelectedText accepted but field value unchanged".to_string(),
-            ));
+            return Err("AXSelectedText accepted but field value unchanged".to_string());
         }
     }
 
-    Ok(TextInsertOutcome::Inserted)
-}
-
-/// Reject roles that are definitively NOT text inputs. Matches the Windows
-/// deny-list approach: buttons, toggles, indicators, menus, containers like
-/// lists/tables/trees, and window chrome are rejected. Everything else (text
-/// fields, web areas, groups, scroll areas, custom/unknown roles, etc.) is
-/// assumed to potentially accept text.
-fn is_non_text_role(role: &str) -> bool {
-    matches!(
-        role,
-        // Buttons / toggles
-        "AXButton"
-            | "AXPopUpButton"
-            | "AXMenuButton"
-            | "AXCheckBox"
-            | "AXRadioButton"
-            | "AXDisclosureTriangle"
-            // Indicators / sliders
-            | "AXSlider"
-            | "AXProgressIndicator"
-            | "AXBusyIndicator"
-            | "AXLevelIndicator"
-            | "AXValueIndicator"
-            | "AXIncrementor"
-            // Visual / pickers
-            | "AXImage"
-            | "AXColorWell"
-            // Menus
-            | "AXMenu"
-            | "AXMenuBar"
-            | "AXMenuItem"
-            // Lists / tables / trees (Finder desktop, outlines, data grids)
-            | "AXList"
-            | "AXOutline"
-            | "AXTable"
-            | "AXGrid"
-            | "AXRow"
-            | "AXColumn"
-            | "AXCell"
-            // Tabs
-            | "AXTabGroup"
-            // Links
-            | "AXLink"
-            // Non-editable text / content areas
-            | "AXStaticText"
-            | "AXHeading"
-            // Generic containers
-            | "AXGroup"
-            | "AXScrollArea"
-            // Window chrome
-            | "AXScrollBar"
-            | "AXToolbar"
-            | "AXGrowArea"
-            | "AXRuler"
-            | "AXSplitter"
-            | "AXHandle"
-            | "AXMatte"
-            // Top-level containers
-            | "AXWindow"
-            | "AXApplication"
-    )
-}
-
-pub fn is_text_input_focused() -> bool {
-    unsafe {
-        let ax_focused = CFString::new("AXFocusedUIElement");
-        let ax_role = CFString::new("AXRole");
-
-        let system_wide = AXUIElementCreateSystemWide();
-        if system_wide.is_null() {
-            return false;
-        }
-
-        let mut focused: CFTypeRef = ptr::null();
-        let result = AXUIElementCopyAttributeValue(
-            system_wide,
-            ax_focused.as_concrete_TypeRef(),
-            &mut focused,
-        );
-        CFRelease(system_wide);
-
-        if result != AX_ERROR_SUCCESS || focused.is_null() {
-            return false;
-        }
-
-        let role = get_string_attribute(focused, ax_role.as_concrete_TypeRef());
-        CFRelease(focused);
-
-        !is_non_text_role(role.as_deref().unwrap_or("unknown"))
-    }
+    Ok(())
 }
 
 pub fn get_selected_text() -> Option<String> {
@@ -1013,3 +901,4 @@ pub fn get_selected_text() -> Option<String> {
 
     selected.filter(|s| !s.is_empty())
 }
+

--- a/apps/desktop/src-tauri/src/platform/macos/input.rs
+++ b/apps/desktop/src-tauri/src/platform/macos/input.rs
@@ -5,59 +5,51 @@ use std::{thread, time::Duration};
 use super::accessibility;
 
 const KEY_C: CGKeyCode = 8;
+const KEY_SPACE: CGKeyCode = 49;
 const KEY_V: CGKeyCode = 9;
 
 pub(crate) fn paste_text_into_focused_field(
     text: &str,
     _keybind: Option<&str>,
-) -> Result<crate::commands::PasteMethod, String> {
+) -> Result<(), String> {
     if text.trim().is_empty() {
-        return Ok(crate::commands::PasteMethod::Accessibility);
-    }
-
-    if !accessibility::is_text_input_focused() {
-        log::info!("No text input focused, signalling noTarget for clipboard fallback");
-        return Ok(crate::commands::PasteMethod::NoTarget);
+        return Ok(());
     }
 
     match accessibility::insert_text_at_cursor(text) {
-        Ok(accessibility::TextInsertOutcome::Inserted) => {
-            Ok(crate::commands::PasteMethod::Accessibility)
-        }
-        Ok(accessibility::TextInsertOutcome::RequiresClipboardPaste(reason)) => {
-            log::warn!(
-                "Accessibility insert failed ({reason}), falling back to clipboard paste"
-            );
-            paste_via_clipboard(text)?;
-            Ok(crate::commands::PasteMethod::Clipboard)
-        }
-        Ok(accessibility::TextInsertOutcome::NoTarget(reason)) => {
-            log::warn!("No text field target: {reason}");
-            Ok(crate::commands::PasteMethod::NoTarget)
-        }
+        Ok(()) => Ok(()),
         Err(err) => {
-            log::error!("Accessibility insert failed unexpectedly: {err}");
-            paste_via_clipboard(text)?;
-            Ok(crate::commands::PasteMethod::Clipboard)
+            log::warn!("Accessibility insert failed ({err}), falling back to clipboard paste");
+            paste_via_clipboard(text)
         }
     }
 }
 
 fn paste_via_clipboard(text: &str) -> Result<(), String> {
-    let mut clipboard =
-        arboard::Clipboard::new().map_err(|err| format!("clipboard unavailable: {err}"))?;
-    let previous = crate::platform::SavedClipboard::save(&mut clipboard);
-    clipboard
-        .set_text(text.to_string())
-        .map_err(|err| format!("failed to store clipboard text: {err}"))?;
+    let trimmed_text = text.trim_end_matches(' ');
+    let trailing_spaces = text.len() - trimmed_text.len();
 
-    thread::sleep(Duration::from_millis(50));
-    simulate_cmd_v()?;
+    if !trimmed_text.is_empty() {
+        let mut clipboard =
+            arboard::Clipboard::new().map_err(|err| format!("clipboard unavailable: {err}"))?;
+        let previous = crate::platform::SavedClipboard::save(&mut clipboard);
+        clipboard
+            .set_text(trimmed_text.to_string())
+            .map_err(|err| format!("failed to store clipboard text: {err}"))?;
 
-    thread::spawn(move || {
-        thread::sleep(Duration::from_millis(800));
-        previous.restore();
-    });
+        thread::sleep(Duration::from_millis(50));
+        simulate_cmd_v()?;
+
+        thread::spawn(move || {
+            thread::sleep(Duration::from_millis(800));
+            previous.restore();
+        });
+    }
+
+    for _ in 0..trailing_spaces {
+        thread::sleep(Duration::from_millis(10));
+        simulate_keypress(KEY_SPACE, CGEventFlags::empty())?;
+    }
 
     Ok(())
 }

--- a/apps/desktop/src-tauri/src/platform/windows/accessibility.rs
+++ b/apps/desktop/src-tauri/src/platform/windows/accessibility.rs
@@ -434,6 +434,15 @@ pub fn get_selected_text() -> Option<String> {
     get_selected_text_clipboard()
 }
 
+pub fn check_focused_paste_target() -> crate::commands::PasteTargetState {
+    use crate::commands::PasteTargetState;
+    match try_is_text_input_focused() {
+        Ok(true) => PasteTargetState::Editable,
+        Ok(false) => PasteTargetState::NotEditable,
+        Err(_) => PasteTargetState::Unknown,
+    }
+}
+
 fn try_get_selected_text_uia() -> Result<Option<String>, windows::core::Error> {
     unsafe {
         let _ = CoInitializeEx(None, COINIT_MULTITHREADED);

--- a/apps/desktop/src-tauri/src/platform/windows/accessibility.rs
+++ b/apps/desktop/src-tauri/src/platform/windows/accessibility.rs
@@ -10,7 +10,7 @@ use windows::Win32::UI::Accessibility::{
     UIA_AppBarControlTypeId, UIA_ButtonControlTypeId, UIA_CalendarControlTypeId,
     UIA_CheckBoxControlTypeId, UIA_ComboBoxControlTypeId, UIA_ControlTypePropertyId,
     UIA_CustomControlTypeId, UIA_DataGridControlTypeId, UIA_DataItemControlTypeId,
-    UIA_DocumentControlTypeId, UIA_GroupControlTypeId,
+    UIA_DocumentControlTypeId, UIA_EditControlTypeId, UIA_GroupControlTypeId,
     UIA_HeaderControlTypeId, UIA_HeaderItemControlTypeId, UIA_HelpTextPropertyId,
     UIA_HyperlinkControlTypeId, UIA_ImageControlTypeId, UIA_ListControlTypeId,
     UIA_ListItemControlTypeId, UIA_MenuBarControlTypeId, UIA_MenuControlTypeId,
@@ -110,49 +110,25 @@ fn try_is_text_input_focused() -> Result<bool, windows::core::Error> {
         let focused = automation.GetFocusedElement()?;
         let control_type = get_control_type(&focused);
 
-        // Rather than trying to prove a control IS a text input (which
-        // is unreliable — many editors use MSAA, custom frameworks, or
-        // web renderers that don't expose UIA patterns), reject control
-        // types that are definitively NOT text inputs. Everything else
-        // (Edit, Document, Custom, Pane, ComboBox, etc.) is assumed to
-        // potentially accept text.
-        Ok(!is_non_text_control(control_type))
-    }
-}
+        if matches!(
+            control_type,
+            value if value == UIA_EditControlTypeId.0 || value == UIA_DocumentControlTypeId.0
+        ) {
+            return Ok(true);
+        }
 
-fn is_non_text_control(control_type: i32) -> bool {
-    [
-        UIA_AppBarControlTypeId.0,
-        UIA_ButtonControlTypeId.0,
-        UIA_CalendarControlTypeId.0,
-        UIA_CheckBoxControlTypeId.0,
-        UIA_DataGridControlTypeId.0,
-        UIA_HeaderControlTypeId.0,
-        UIA_HeaderItemControlTypeId.0,
-        UIA_HyperlinkControlTypeId.0,
-        UIA_ImageControlTypeId.0,
-        UIA_ListControlTypeId.0,
-        UIA_ListItemControlTypeId.0,
-        UIA_MenuControlTypeId.0,
-        UIA_MenuBarControlTypeId.0,
-        UIA_MenuItemControlTypeId.0,
-        UIA_ProgressBarControlTypeId.0,
-        UIA_RadioButtonControlTypeId.0,
-        UIA_SemanticZoomControlTypeId.0,
-        UIA_SliderControlTypeId.0,
-        UIA_SplitButtonControlTypeId.0,
-        UIA_StatusBarControlTypeId.0,
-        UIA_TabControlTypeId.0,
-        UIA_TabItemControlTypeId.0,
-        UIA_TableControlTypeId.0,
-        UIA_ThumbControlTypeId.0,
-        UIA_TitleBarControlTypeId.0,
-        UIA_ToolBarControlTypeId.0,
-        UIA_TreeControlTypeId.0,
-        UIA_TreeItemControlTypeId.0,
-        UIA_WindowControlTypeId.0,
-    ]
-    .contains(&control_type)
+        let text_pattern = focused.GetCurrentPattern(UIA_TextPatternId)?;
+        if !text_pattern.as_raw().is_null() {
+            return Ok(true);
+        }
+
+        let value_pattern = focused.GetCurrentPattern(UIA_ValuePatternId)?;
+        if !value_pattern.as_raw().is_null() {
+            return Ok(true);
+        }
+
+        Ok(false)
+    }
 }
 
 pub fn get_screen_context() -> ScreenContextInfo {

--- a/apps/desktop/src-tauri/src/platform/windows/input.rs
+++ b/apps/desktop/src-tauri/src/platform/windows/input.rs
@@ -19,14 +19,9 @@ pub struct WindowTargetInfo {
 pub(crate) fn paste_text_into_focused_field(
     text: &str,
     keybind: Option<&str>,
-) -> Result<crate::commands::PasteMethod, String> {
+) -> Result<(), String> {
     if text.trim().is_empty() {
-        return Ok(crate::commands::PasteMethod::Clipboard);
-    }
-
-    if !super::accessibility::is_text_input_focused() {
-        log::info!("No text input focused, signalling noTarget for clipboard fallback");
-        return Ok(crate::commands::PasteMethod::NoTarget);
+        return Ok(());
     }
 
     let override_text = env::var("VOQUILL_DEBUG_PASTE_TEXT").ok();
@@ -36,7 +31,7 @@ pub(crate) fn paste_text_into_focused_field(
         target.chars().count()
     );
 
-    paste_via_clipboard(target, keybind).or_else(|err| -> Result<(), String> {
+    paste_via_clipboard(target, keybind).or_else(|err| {
         log::warn!("Clipboard paste failed ({err}), falling back to simulated typing");
         use enigo::{Enigo, KeyboardControllable};
         let mut enigo = Enigo::new();
@@ -44,8 +39,7 @@ pub(crate) fn paste_text_into_focused_field(
         thread::sleep(Duration::from_millis(50));
         enigo.key_sequence(target);
         Ok(())
-    })?;
-    Ok(crate::commands::PasteMethod::Clipboard)
+    })
 }
 
 fn is_console_window() -> bool {

--- a/apps/desktop/src/utils/output-routing.utils.ts
+++ b/apps/desktop/src/utils/output-routing.utils.ts
@@ -3,9 +3,14 @@ import type {
   RouteTranscriptOutputArgs,
   RouteTranscriptOutputResult,
 } from "@voquill/types";
+import { getIntl } from "../i18n/intl";
 import { getAppState } from "../store";
+import { getLogger } from "./log.utils";
+import { sendPillFlashMessage } from "./overlay.utils";
 import { sanitizeIndentation } from "./string.utils";
 import { getMyUserPreferences } from "./user.utils";
+
+type PasteTargetState = "editable" | "not_editable" | "unknown";
 
 export const routeTranscriptOutput = async (
   args: RouteTranscriptOutputArgs,
@@ -55,8 +60,46 @@ export const insertLocalTranscriptOutput = async (
   text: string,
   keybind: string | null,
 ): Promise<void> => {
+  const sanitized = sanitizeIndentation(text);
+
+  checkFocusedPasteTarget().then((target) => {
+    if (target === "not_editable") {
+      getLogger().info(
+        "Focused element was not editable, copying transcription to clipboard",
+      );
+      copyToClipboardFallback(sanitized);
+    }
+  });
+
   await invoke<void>("paste", {
-    text: sanitizeIndentation(text),
+    text: sanitized,
     keybind,
   });
+};
+
+const checkFocusedPasteTarget = async (): Promise<PasteTargetState> => {
+  try {
+    return await invoke<PasteTargetState>("check_focused_paste_target");
+  } catch (error) {
+    getLogger().verbose(`check_focused_paste_target failed: ${error}`);
+    return "unknown";
+  }
+};
+
+const copyToClipboardFallback = async (text: string): Promise<void> => {
+  try {
+    await invoke<void>("copy_to_clipboard", { text });
+    sendPillFlashMessage(
+      getIntl().formatMessage({
+        defaultMessage: "Transcript copied to clipboard",
+      }),
+    );
+  } catch (error) {
+    getLogger().error(`Clipboard fallback failed: ${error}`);
+    sendPillFlashMessage(
+      getIntl().formatMessage({
+        defaultMessage: "Couldn't paste transcription",
+      }),
+    );
+  }
 };

--- a/apps/desktop/src/utils/output-routing.utils.ts
+++ b/apps/desktop/src/utils/output-routing.utils.ts
@@ -3,14 +3,9 @@ import type {
   RouteTranscriptOutputArgs,
   RouteTranscriptOutputResult,
 } from "@voquill/types";
-import { showToast } from "../actions/toast.actions";
-import { getIntl } from "../i18n/intl";
 import { getAppState } from "../store";
-import { getLogger } from "./log.utils";
 import { sanitizeIndentation } from "./string.utils";
 import { getMyUserPreferences } from "./user.utils";
-
-type PasteMethod = "accessibility" | "clipboard" | "noTarget";
 
 export const routeTranscriptOutput = async (
   args: RouteTranscriptOutputArgs,
@@ -60,31 +55,8 @@ export const insertLocalTranscriptOutput = async (
   text: string,
   keybind: string | null,
 ): Promise<void> => {
-  const sanitized = sanitizeIndentation(text);
-  if (!sanitized.trim()) return;
-
-  let method: PasteMethod;
-  try {
-    method = await invoke<PasteMethod>("paste", {
-      text: sanitized,
-      keybind,
-    });
-  } catch (error) {
-    getLogger().error(`Paste command failed: ${error}`);
-    method = "noTarget";
-  }
-
-  if (method !== "noTarget") return;
-
-  try {
-    await invoke<void>("copy_to_clipboard", { text: sanitized });
-    await showToast({
-      message: getIntl().formatMessage({
-        defaultMessage: "Text copied to clipboard",
-      }),
-      toastType: "info",
-    });
-  } catch (error) {
-    getLogger().error(`Clipboard fallback failed: ${error}`);
-  }
+  await invoke<void>("paste", {
+    text: sanitizeIndentation(text),
+    keybind,
+  });
 };


### PR DESCRIPTION
## What changed?

Added `check_focused_paste_target` command to improve paste functionality detection. This command determines whether the currently focused element is an editable text field, which enhances the reliability of paste operations across different platforms and window managers.

Key changes:
- Added new `check_focused_paste_target` command to the Tauri command registry
- Implemented platform-specific logic for Linux (both Wayland and X11)
- Enhanced paste reliability by checking target state before attempting to paste

<!-- Demo video/screenshots -->

## How is it tested?

- [x] Manual verification
- [x] Code inspection

Tested manually on Linux with both Wayland and X11 sessions to verify:
- Correct detection of editable text fields
- Proper handling of non-editable elements
- Integration with existing paste functionality

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added focused paste target detection to identify whether the active field can accept input before attempting to paste.

* **Bug Fixes**
  * Improved clipboard fallback handling for non-editable fields during paste operations.

* **Refactor**
  * Simplified paste operation flow by separating target detection from paste execution across all platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->