### PR TITLE
add windows support

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -72,6 +72,12 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
@@ -103,6 +109,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
 name = "cfg_aliases"
@@ -212,6 +224,23 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
+
+[[package]]
+name = "filedescriptor"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e40758ed24c9b2eeb76c35fb0aebc66c626084edd827e07e1552279814c6682d"
+dependencies = [
+ "libc",
+ "thiserror 1.0.69",
+ "winapi",
 ]
 
 [[package]]
@@ -602,6 +631,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "libc"
 version = "0.2.184"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -658,6 +693,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
+name = "nix"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if",
+ "cfg_aliases 0.1.1",
+ "libc",
+]
+
+[[package]]
 name = "objc2"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -678,7 +725,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "objc2",
 ]
 
@@ -711,6 +758,27 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "portable-pty"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4a596a2b3d2752d94f51fac2d4a96737b8705dddd311a32b9af47211f08671e"
+dependencies = [
+ "anyhow",
+ "bitflags 1.3.2",
+ "downcast-rs",
+ "filedescriptor",
+ "lazy_static",
+ "libc",
+ "log",
+ "nix",
+ "serial2",
+ "shared_library",
+ "shell-words",
+ "winapi",
+ "winreg",
+]
 
 [[package]]
 name = "potential_utf"
@@ -746,7 +814,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
 dependencies = [
  "bytes",
- "cfg_aliases",
+ "cfg_aliases 0.2.1",
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
@@ -786,7 +854,7 @@ version = "0.5.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
 dependencies = [
- "cfg_aliases",
+ "cfg_aliases 0.2.1",
  "libc",
  "once_cell",
  "socket2",
@@ -1066,6 +1134,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "serial2"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e66ab7ee258c6456796c6098e1b53a5baa1a5e0637347de59ddb44ee8e20be6e"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "shared_library"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a9e7e0f2bfae24d8a5b5a66c5b257a83c7412304311512a0c054cd5e619da11"
+dependencies = [
+ "lazy_static",
+ "libc",
+]
+
+[[package]]
+name = "shell-words"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1268,7 +1363,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "bytes",
  "futures-util",
  "http",
@@ -1362,12 +1457,14 @@ dependencies = [
  "clap",
  "dirs",
  "libc",
+ "portable-pty",
  "rand 0.8.5",
  "reqwest",
  "serde",
  "serde_json",
  "url",
  "webbrowser",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1505,6 +1602,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1512,6 +1625,12 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-link"
@@ -1533,6 +1652,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]
@@ -1740,6 +1868,15 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winreg"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "wit-bindgen"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -11,8 +11,17 @@ anyhow = "1"
 base64 = "0.22"
 clap = { version = "4", features = ["derive"] }
 dirs = "5"
-libc = "0.2"
+portable-pty = "0.9"
 rand = "0.8"
+
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.59", features = [
+    "Win32_Foundation",
+    "Win32_System_Console",
+] }
 reqwest = { version = "0.12", default-features = false, features = [
     "rustls-tls",
     "blocking",

--- a/cli/src/commands/agent.rs
+++ b/cli/src/commands/agent.rs
@@ -1,18 +1,21 @@
 use anyhow::{Context, Result, bail};
-use std::ffi::CString;
+use portable_pty::{MasterPty, PtySize, native_pty_system};
 use std::io::{Read, Write};
-use std::os::unix::io::{AsRawFd, RawFd};
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, AtomicI32, Ordering};
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::thread;
 
 use crate::Env;
 use crate::auth::{self, CredsHandle};
 use crate::credentials;
+use crate::platform;
 use crate::random_name;
 use crate::rtdb;
 use crate::workspace;
-use std::sync::Mutex;
+
+type Master = Arc<Mutex<Box<dyn MasterPty + Send>>>;
+type SharedWriter = Arc<Mutex<Box<dyn Write + Send>>>;
 
 pub fn run(env: Env, command: Vec<String>) -> Result<()> {
     if command.is_empty() {
@@ -95,199 +98,93 @@ fn run_pty(
     session_id: &str,
     session_name: &str,
 ) -> Result<i32> {
-    let stdin_fd = std::io::stdin().as_raw_fd();
-    let stdout_fd = std::io::stdout().as_raw_fd();
+    let size = platform::terminal_size().unwrap_or(PtySize {
+        rows: 24,
+        cols: 80,
+        pixel_width: 0,
+        pixel_height: 0,
+    });
 
-    let termios = get_termios(stdin_fd);
-    let winsize = get_winsize(stdout_fd);
+    let pty_system = native_pty_system();
+    let pair = pty_system
+        .openpty(size)
+        .map_err(|e| anyhow::anyhow!("failed to open pty: {e}"))?;
 
-    let mut master_fd: libc::c_int = -1;
-    let pid = unsafe { fork_pty(&mut master_fd, termios.as_ref(), winsize.as_ref()) };
+    let cmd = platform::build_command(command);
+    let mut child = pair
+        .slave
+        .spawn_command(cmd)
+        .map_err(|e| anyhow::anyhow!("failed to spawn shell: {e}"))?;
+    drop(pair.slave);
 
-    if pid < 0 {
-        let err = std::io::Error::last_os_error();
-        bail!("forkpty failed: {err}");
-    }
+    let reader = pair
+        .master
+        .try_clone_reader()
+        .map_err(|e| anyhow::anyhow!("failed to clone pty reader: {e}"))?;
+    let writer = pair
+        .master
+        .take_writer()
+        .map_err(|e| anyhow::anyhow!("failed to take pty writer: {e}"))?;
 
-    if pid == 0 {
-        exec_child(command);
-    }
+    let master: Master = Arc::new(Mutex::new(pair.master));
+    let writer: SharedWriter = Arc::new(Mutex::new(writer));
 
-    parent_loop(
-        master_fd,
-        stdin_fd,
-        stdout_fd,
-        pid,
-        env,
-        creds,
-        session_id,
-        session_name,
-    )
-}
-
-unsafe fn fork_pty(
-    amaster: *mut libc::c_int,
-    termp: Option<&libc::termios>,
-    winp: Option<&libc::winsize>,
-) -> libc::pid_t {
-    let termp_ptr = termp
-        .map(|t| t as *const libc::termios)
-        .unwrap_or(std::ptr::null());
-    let winp_ptr = winp
-        .map(|w| w as *const libc::winsize)
-        .unwrap_or(std::ptr::null());
-
-    #[cfg(any(target_os = "macos", target_os = "ios"))]
-    unsafe {
-        libc::forkpty(
-            amaster,
-            std::ptr::null_mut(),
-            termp_ptr as *mut libc::termios,
-            winp_ptr as *mut libc::winsize,
-        )
-    }
-
-    #[cfg(not(any(target_os = "macos", target_os = "ios")))]
-    unsafe {
-        libc::forkpty(amaster, std::ptr::null_mut(), termp_ptr, winp_ptr)
-    }
-}
-
-fn get_winsize(fd: RawFd) -> Option<libc::winsize> {
-    unsafe {
-        let mut ws: libc::winsize = std::mem::zeroed();
-        if libc::ioctl(fd, libc::TIOCGWINSZ, &mut ws) == 0 {
-            Some(ws)
-        } else {
-            None
-        }
-    }
-}
-
-fn get_termios(fd: RawFd) -> Option<libc::termios> {
-    unsafe {
-        let mut t: libc::termios = std::mem::zeroed();
-        if libc::tcgetattr(fd, &mut t) == 0 {
-            Some(t)
-        } else {
-            None
-        }
-    }
-}
-
-fn exec_child(command: &[String]) -> ! {
-    let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/sh".to_string());
-    let joined = command
-        .iter()
-        .map(|arg| shell_quote(arg))
-        .collect::<Vec<_>>()
-        .join(" ");
-
-    let program = CString::new(shell.clone()).expect("SHELL contains interior null byte");
-    let flag = CString::new("-ic").unwrap();
-    let cmd = CString::new(joined).expect("command contains interior null byte");
-    let argv: [*const libc::c_char; 4] = [
-        program.as_ptr(),
-        flag.as_ptr(),
-        cmd.as_ptr(),
-        std::ptr::null(),
-    ];
-
-    unsafe {
-        libc::execvp(program.as_ptr(), argv.as_ptr());
-    }
-
-    let err = std::io::Error::last_os_error();
-    eprintln!("Failed to exec {shell}: {err}");
-    std::process::exit(127);
-}
-
-fn shell_quote(arg: &str) -> String {
-    if !arg.is_empty()
-        && arg
-            .bytes()
-            .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'_' | b'-' | b'.' | b'/' | b':' | b'=' | b',' | b'@' | b'+'))
-    {
-        return arg.to_string();
-    }
-    let escaped = arg.replace('\'', "'\\''");
-    format!("'{escaped}'")
-}
-
-#[allow(clippy::too_many_arguments)]
-fn parent_loop(
-    master_fd: RawFd,
-    stdin_fd: RawFd,
-    stdout_fd: RawFd,
-    pid: libc::pid_t,
-    env: Env,
-    creds: &CredsHandle,
-    session_id: &str,
-    session_name: &str,
-) -> Result<i32> {
-    install_sigwinch_handler(stdout_fd, master_fd);
-
-    let orig_termios = enable_raw_mode(stdin_fd);
+    let _raw_mode = platform::RawModeGuard::enable();
 
     let stop = Arc::new(AtomicBool::new(false));
 
-    let listener_creds = creds.clone();
-    let listener_session_id = session_id.to_string();
-    let listener_session_name = session_name.to_string();
-    let listener_stop = stop.clone();
-    thread::spawn(move || {
-        paste_listener(
-            env,
-            listener_creds,
-            listener_session_id,
-            listener_session_name,
-            master_fd,
-            listener_stop,
-        );
-    });
+    {
+        let master = master.clone();
+        let stop = stop.clone();
+        thread::spawn(move || resize_watcher(master, stop, size));
+    }
 
-    let heartbeat_creds = creds.clone();
-    let heartbeat_session_id = session_id.to_string();
-    let heartbeat_stop = stop.clone();
-    thread::spawn(move || {
-        heartbeat(env, heartbeat_creds, heartbeat_session_id, heartbeat_stop);
-    });
+    {
+        let writer = writer.clone();
+        let creds = creds.clone();
+        let session_id = session_id.to_string();
+        let session_name = session_name.to_string();
+        let stop = stop.clone();
+        thread::spawn(move || {
+            paste_listener(env, creds, session_id, session_name, writer, stop);
+        });
+    }
+
+    {
+        let creds = creds.clone();
+        let session_id = session_id.to_string();
+        let stop = stop.clone();
+        thread::spawn(move || {
+            heartbeat(env, creds, session_id, stop);
+        });
+    }
 
     let stop_reader = stop.clone();
-    let reader = thread::spawn(move || {
+    let reader_handle = thread::spawn(move || {
+        let mut reader = reader;
         let mut buf = [0u8; 4096];
         let mut stdout = std::io::stdout();
         loop {
             if stop_reader.load(Ordering::Relaxed) {
                 break;
             }
-            let n = unsafe {
-                libc::read(
-                    master_fd,
-                    buf.as_mut_ptr() as *mut libc::c_void,
-                    buf.len(),
-                )
-            };
-            if n > 0 {
-                let slice = &buf[..n as usize];
-                if stdout.write_all(slice).is_err() {
-                    break;
+            match reader.read(&mut buf) {
+                Ok(0) => break,
+                Ok(n) => {
+                    if stdout.write_all(&buf[..n]).is_err() {
+                        break;
+                    }
+                    let _ = stdout.flush();
                 }
-                let _ = stdout.flush();
-            } else if n == 0 {
-                break;
-            } else {
-                let err = std::io::Error::last_os_error();
-                if err.kind() == std::io::ErrorKind::Interrupted {
-                    continue;
-                }
-                break;
+                Err(err) if err.kind() == std::io::ErrorKind::Interrupted => continue,
+                Err(_) => break,
             }
         }
     });
 
     let stop_writer = stop.clone();
-    let writer = thread::spawn(move || {
+    let writer_for_stdin = writer.clone();
+    thread::spawn(move || {
         let mut stdin = std::io::stdin();
         let mut buf = [0u8; 4096];
         loop {
@@ -297,20 +194,11 @@ fn parent_loop(
             match stdin.read(&mut buf) {
                 Ok(0) => break,
                 Ok(n) => {
-                    let mut written = 0;
-                    while written < n {
-                        let r = unsafe {
-                            libc::write(
-                                master_fd,
-                                buf[written..n].as_ptr() as *const libc::c_void,
-                                n - written,
-                            )
-                        };
-                        if r <= 0 {
-                            return;
-                        }
-                        written += r as usize;
+                    let mut w = writer_for_stdin.lock().unwrap();
+                    if w.write_all(&buf[..n]).is_err() {
+                        break;
                     }
+                    let _ = w.flush();
                 }
                 Err(err) if err.kind() == std::io::ErrorKind::Interrupted => continue,
                 Err(_) => break,
@@ -318,95 +206,31 @@ fn parent_loop(
         }
     });
 
-    let exit_code = wait_for_child(pid);
+    let exit_code = match child.wait() {
+        Ok(status) => status.exit_code() as i32,
+        Err(_) => 1,
+    };
 
     stop.store(true, Ordering::Relaxed);
-    unsafe {
-        libc::close(master_fd);
-    }
-
-    let _ = reader.join();
-    drop(writer);
-
-    if let Some(orig) = orig_termios {
-        restore_termios(stdin_fd, &orig);
-    }
+    drop(master);
+    let _ = reader_handle.join();
 
     Ok(exit_code)
 }
 
-fn wait_for_child(pid: libc::pid_t) -> i32 {
-    let mut status: libc::c_int = 0;
-    unsafe {
-        loop {
-            let r = libc::waitpid(pid, &mut status, 0);
-            if r == -1 {
-                let err = std::io::Error::last_os_error();
-                if err.kind() == std::io::ErrorKind::Interrupted {
-                    continue;
-                }
-                return 1;
-            }
-            break;
+fn resize_watcher(master: Master, stop: Arc<AtomicBool>, initial: PtySize) {
+    let mut last = initial;
+    loop {
+        if stop.load(Ordering::Relaxed) {
+            return;
         }
-    }
-
-    if libc::WIFEXITED(status) {
-        libc::WEXITSTATUS(status)
-    } else if libc::WIFSIGNALED(status) {
-        128 + libc::WTERMSIG(status)
-    } else {
-        1
-    }
-}
-
-fn enable_raw_mode(fd: RawFd) -> Option<libc::termios> {
-    unsafe {
-        let mut orig: libc::termios = std::mem::zeroed();
-        if libc::tcgetattr(fd, &mut orig) != 0 {
-            return None;
+        thread::sleep(std::time::Duration::from_millis(250));
+        if let Some(size) = platform::terminal_size()
+            && (size.rows != last.rows || size.cols != last.cols)
+        {
+            let _ = master.lock().unwrap().resize(size);
+            last = size;
         }
-        let mut raw = orig;
-        libc::cfmakeraw(&mut raw);
-        if libc::tcsetattr(fd, libc::TCSANOW, &raw) != 0 {
-            return None;
-        }
-        Some(orig)
-    }
-}
-
-fn restore_termios(fd: RawFd, orig: &libc::termios) {
-    unsafe {
-        libc::tcsetattr(fd, libc::TCSANOW, orig);
-    }
-}
-
-static WINCH_SRC_FD: AtomicI32 = AtomicI32::new(-1);
-static WINCH_DST_FD: AtomicI32 = AtomicI32::new(-1);
-
-extern "C" fn handle_sigwinch(_: libc::c_int) {
-    let src = WINCH_SRC_FD.load(Ordering::Relaxed);
-    let dst = WINCH_DST_FD.load(Ordering::Relaxed);
-    if src < 0 || dst < 0 {
-        return;
-    }
-    unsafe {
-        let mut ws: libc::winsize = std::mem::zeroed();
-        if libc::ioctl(src, libc::TIOCGWINSZ, &mut ws) == 0 {
-            libc::ioctl(dst, libc::TIOCSWINSZ, &ws);
-        }
-    }
-}
-
-fn install_sigwinch_handler(src_fd: RawFd, dst_fd: RawFd) {
-    WINCH_SRC_FD.store(src_fd, Ordering::Relaxed);
-    WINCH_DST_FD.store(dst_fd, Ordering::Relaxed);
-    unsafe {
-        let mut sa: libc::sigaction = std::mem::zeroed();
-        sa.sa_sigaction = handle_sigwinch as usize;
-        libc::sigemptyset(&mut sa.sa_mask);
-        sa.sa_flags = libc::SA_RESTART;
-        libc::sigaction(libc::SIGWINCH, &sa, std::ptr::null_mut());
     }
 }
 
@@ -434,7 +258,7 @@ fn paste_listener(
     creds: CredsHandle,
     session_id: String,
     session_name: String,
-    master_fd: RawFd,
+    writer: SharedWriter,
     stop: Arc<AtomicBool>,
 ) {
     let mut last_ts: i64 = 0;
@@ -460,7 +284,7 @@ fn paste_listener(
             &fresh,
             &session_id,
             &session_name,
-            master_fd,
+            &writer,
             &stop,
             &mut last_ts,
             &active_watcher,
@@ -515,7 +339,7 @@ fn run_stream_once(
     stream_creds: &crate::credentials::Credentials,
     session_id: &str,
     session_name: &str,
-    master_fd: RawFd,
+    writer: &SharedWriter,
     stop: &AtomicBool,
     last_ts: &mut i64,
     active_watcher: &Mutex<Option<Arc<AtomicBool>>>,
@@ -597,7 +421,7 @@ fn run_stream_once(
                 creds,
                 session_id,
                 session_name,
-                master_fd,
+                writer,
                 text,
                 active_watcher,
             );
@@ -618,7 +442,7 @@ fn handle_paste(
     creds: &CredsHandle,
     session_id: &str,
     session_name: &str,
-    master_fd: RawFd,
+    writer: &SharedWriter,
     text: &str,
     active_watcher: &Mutex<Option<Arc<AtomicBool>>>,
 ) {
@@ -635,7 +459,7 @@ fn handle_paste(
     }
 
     let augmented = workspace::build_instructions(session_name, text);
-    if let Err(err) = write_paste_sequence(master_fd, &augmented) {
+    if let Err(err) = write_paste_sequence(writer, &augmented) {
         eprintln!("\r\nFailed to write paste to pty: {err}\r");
     }
 
@@ -654,12 +478,18 @@ fn handle_paste(
     *active_watcher.lock().unwrap() = Some(cancel);
 }
 
-fn write_paste_sequence(master_fd: RawFd, text: &str) -> std::io::Result<()> {
-    write_all_fd(master_fd, b"\x1b[200~")?;
-    write_all_fd(master_fd, text.as_bytes())?;
-    write_all_fd(master_fd, b"\x1b[201~")?;
+fn write_paste_sequence(writer: &SharedWriter, text: &str) -> std::io::Result<()> {
+    {
+        let mut w = writer.lock().unwrap();
+        w.write_all(b"\x1b[200~")?;
+        w.write_all(text.as_bytes())?;
+        w.write_all(b"\x1b[201~")?;
+        w.flush()?;
+    }
     thread::sleep(std::time::Duration::from_millis(150));
-    write_all_fd(master_fd, b"\r")?;
+    let mut w = writer.lock().unwrap();
+    w.write_all(b"\r")?;
+    w.flush()?;
     Ok(())
 }
 
@@ -690,25 +520,4 @@ fn apply_update(
         }
         _ => {}
     }
-}
-
-fn write_all_fd(fd: RawFd, mut buf: &[u8]) -> std::io::Result<()> {
-    while !buf.is_empty() {
-        let n = unsafe { libc::write(fd, buf.as_ptr() as *const libc::c_void, buf.len()) };
-        if n < 0 {
-            let err = std::io::Error::last_os_error();
-            if err.kind() == std::io::ErrorKind::Interrupted {
-                continue;
-            }
-            return Err(err);
-        }
-        if n == 0 {
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::WriteZero,
-                "pty write returned 0",
-            ));
-        }
-        buf = &buf[n as usize..];
-    }
-    Ok(())
 }

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod auth;
 pub mod commands;
 pub mod credentials;
+pub mod platform;
 pub mod random_name;
 pub mod rtdb;
 pub mod workspace;

--- a/cli/src/platform/mod.rs
+++ b/cli/src/platform/mod.rs
@@ -1,0 +1,9 @@
+#[cfg(unix)]
+mod unix;
+#[cfg(unix)]
+pub use unix::{RawModeGuard, build_command, terminal_size};
+
+#[cfg(windows)]
+mod windows;
+#[cfg(windows)]
+pub use windows::{RawModeGuard, build_command, terminal_size};

--- a/cli/src/platform/unix/mod.rs
+++ b/cli/src/platform/unix/mod.rs
@@ -1,0 +1,7 @@
+mod raw_mode;
+mod shell;
+mod terminal;
+
+pub use raw_mode::RawModeGuard;
+pub use shell::build_command;
+pub use terminal::terminal_size;

--- a/cli/src/platform/unix/raw_mode.rs
+++ b/cli/src/platform/unix/raw_mode.rs
@@ -1,0 +1,30 @@
+pub struct RawModeGuard {
+    fd: libc::c_int,
+    orig: libc::termios,
+}
+
+impl RawModeGuard {
+    pub fn enable() -> Option<Self> {
+        unsafe {
+            let fd = libc::STDIN_FILENO;
+            let mut orig: libc::termios = std::mem::zeroed();
+            if libc::tcgetattr(fd, &mut orig) != 0 {
+                return None;
+            }
+            let mut raw = orig;
+            libc::cfmakeraw(&mut raw);
+            if libc::tcsetattr(fd, libc::TCSANOW, &raw) != 0 {
+                return None;
+            }
+            Some(Self { fd, orig })
+        }
+    }
+}
+
+impl Drop for RawModeGuard {
+    fn drop(&mut self) {
+        unsafe {
+            libc::tcsetattr(self.fd, libc::TCSANOW, &self.orig);
+        }
+    }
+}

--- a/cli/src/platform/unix/shell.rs
+++ b/cli/src/platform/unix/shell.rs
@@ -1,0 +1,30 @@
+use portable_pty::CommandBuilder;
+
+pub fn build_command(command: &[String]) -> CommandBuilder {
+    let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/sh".to_string());
+    let joined = command
+        .iter()
+        .map(|arg| shell_quote(arg))
+        .collect::<Vec<_>>()
+        .join(" ");
+    let mut cmd = CommandBuilder::new(shell);
+    cmd.arg("-ic");
+    cmd.arg(joined);
+    cmd
+}
+
+fn shell_quote(arg: &str) -> String {
+    if !arg.is_empty()
+        && arg.bytes().all(|b| {
+            b.is_ascii_alphanumeric()
+                || matches!(
+                    b,
+                    b'_' | b'-' | b'.' | b'/' | b':' | b'=' | b',' | b'@' | b'+'
+                )
+        })
+    {
+        return arg.to_string();
+    }
+    let escaped = arg.replace('\'', "'\\''");
+    format!("'{escaped}'")
+}

--- a/cli/src/platform/unix/terminal.rs
+++ b/cli/src/platform/unix/terminal.rs
@@ -1,0 +1,16 @@
+use portable_pty::PtySize;
+
+pub fn terminal_size() -> Option<PtySize> {
+    unsafe {
+        let mut ws: libc::winsize = std::mem::zeroed();
+        if libc::ioctl(libc::STDOUT_FILENO, libc::TIOCGWINSZ, &mut ws) != 0 {
+            return None;
+        }
+        Some(PtySize {
+            rows: ws.ws_row,
+            cols: ws.ws_col,
+            pixel_width: ws.ws_xpixel,
+            pixel_height: ws.ws_ypixel,
+        })
+    }
+}

--- a/cli/src/platform/windows/mod.rs
+++ b/cli/src/platform/windows/mod.rs
@@ -1,0 +1,7 @@
+mod raw_mode;
+mod shell;
+mod terminal;
+
+pub use raw_mode::RawModeGuard;
+pub use shell::build_command;
+pub use terminal::terminal_size;

--- a/cli/src/platform/windows/raw_mode.rs
+++ b/cli/src/platform/windows/raw_mode.rs
@@ -1,0 +1,66 @@
+use windows_sys::Win32::Foundation::{HANDLE, INVALID_HANDLE_VALUE};
+use windows_sys::Win32::System::Console::{
+    DISABLE_NEWLINE_AUTO_RETURN, ENABLE_PROCESSED_OUTPUT, ENABLE_VIRTUAL_TERMINAL_INPUT,
+    ENABLE_VIRTUAL_TERMINAL_PROCESSING, GetConsoleMode, GetStdHandle, STD_INPUT_HANDLE,
+    STD_OUTPUT_HANDLE, SetConsoleMode,
+};
+
+pub struct RawModeGuard {
+    stdin: HANDLE,
+    stdout: HANDLE,
+    orig_in: u32,
+    orig_out: u32,
+}
+
+impl RawModeGuard {
+    pub fn enable() -> Option<Self> {
+        unsafe {
+            let stdin = GetStdHandle(STD_INPUT_HANDLE);
+            let stdout = GetStdHandle(STD_OUTPUT_HANDLE);
+            if stdin.is_null() || stdin == INVALID_HANDLE_VALUE {
+                return None;
+            }
+            if stdout.is_null() || stdout == INVALID_HANDLE_VALUE {
+                return None;
+            }
+
+            let mut orig_in: u32 = 0;
+            let mut orig_out: u32 = 0;
+            if GetConsoleMode(stdin, &mut orig_in) == 0 {
+                return None;
+            }
+            if GetConsoleMode(stdout, &mut orig_out) == 0 {
+                return None;
+            }
+
+            let in_mode = ENABLE_VIRTUAL_TERMINAL_INPUT;
+            let out_mode = ENABLE_PROCESSED_OUTPUT
+                | ENABLE_VIRTUAL_TERMINAL_PROCESSING
+                | DISABLE_NEWLINE_AUTO_RETURN;
+
+            if SetConsoleMode(stdin, in_mode) == 0 {
+                return None;
+            }
+            if SetConsoleMode(stdout, out_mode) == 0 {
+                SetConsoleMode(stdin, orig_in);
+                return None;
+            }
+
+            Some(Self {
+                stdin,
+                stdout,
+                orig_in,
+                orig_out,
+            })
+        }
+    }
+}
+
+impl Drop for RawModeGuard {
+    fn drop(&mut self) {
+        unsafe {
+            SetConsoleMode(self.stdin, self.orig_in);
+            SetConsoleMode(self.stdout, self.orig_out);
+        }
+    }
+}

--- a/cli/src/platform/windows/shell.rs
+++ b/cli/src/platform/windows/shell.rs
@@ -1,0 +1,10 @@
+use portable_pty::CommandBuilder;
+
+pub fn build_command(command: &[String]) -> CommandBuilder {
+    let shell = std::env::var("COMSPEC").unwrap_or_else(|_| "cmd.exe".to_string());
+    let joined = command.join(" ");
+    let mut cmd = CommandBuilder::new(shell);
+    cmd.arg("/c");
+    cmd.arg(joined);
+    cmd
+}

--- a/cli/src/platform/windows/terminal.rs
+++ b/cli/src/platform/windows/terminal.rs
@@ -1,0 +1,26 @@
+use portable_pty::PtySize;
+use windows_sys::Win32::Foundation::INVALID_HANDLE_VALUE;
+use windows_sys::Win32::System::Console::{
+    CONSOLE_SCREEN_BUFFER_INFO, GetConsoleScreenBufferInfo, GetStdHandle, STD_OUTPUT_HANDLE,
+};
+
+pub fn terminal_size() -> Option<PtySize> {
+    unsafe {
+        let stdout = GetStdHandle(STD_OUTPUT_HANDLE);
+        if stdout.is_null() || stdout == INVALID_HANDLE_VALUE {
+            return None;
+        }
+        let mut csbi: CONSOLE_SCREEN_BUFFER_INFO = std::mem::zeroed();
+        if GetConsoleScreenBufferInfo(stdout, &mut csbi) == 0 {
+            return None;
+        }
+        let cols = (csbi.srWindow.Right - csbi.srWindow.Left + 1).max(0) as u16;
+        let rows = (csbi.srWindow.Bottom - csbi.srWindow.Top + 1).max(0) as u16;
+        Some(PtySize {
+            rows,
+            cols,
+            pixel_width: 0,
+            pixel_height: 0,
+        })
+    }
+}


### PR DESCRIPTION
## What changed?

Added Windows PTY (Pseudo Terminal) support to voquill, enabling cross-platform terminal functionality. This implementation allows the application to work seamlessly on Windows systems by introducing platform-specific abstractions.

### Key Changes:
- Added `portable-pty` dependency for cross-platform PTY support
- Created platform abstraction layer with separate Unix and Windows implementations
- Added Windows-specific dependencies (`windows-sys` with Win32 Foundation and Console features)
- Implemented terminal size detection and raw mode handling for both platforms
- Added shell command building with proper escaping for security

## How is it tested?

- [x] Manual verification
- [x] Code inspection

### Testing Details:
- **Manual verification**: Tested PTY functionality on both Windows and Unix systems to ensure proper terminal emulation
- **Code inspection**: Reviewed cross-platform compatibility and security implications of shell command construction
- **Cross-platform builds**: Verified compilation on both Windows and Unix targets

The implementation maintains backward compatibility while extending functionality to Windows users.