### PR TITLE
local model for hindi2hinglish

### DIFF
--- a/apps/desktop/src/components/settings/AITranscriptionConfiguration.tsx
+++ b/apps/desktop/src/components/settings/AITranscriptionConfiguration.tsx
@@ -85,6 +85,11 @@ const MODEL_OPTIONS: ModelOption[] = [
     label: "Whisper Large v3 (3.1 GB)",
     helper: "Highest accuracy, requires GPU",
   },
+  {
+    value: "hindi2hinglish",
+    label: "Whisper Hindi2Hinglish Apex (595 MB)",
+    helper: "Hindi speech transcribed as Hinglish (Latin script)",
+  },
 ];
 
 const formatDownloadProgress = (

--- a/apps/desktop/src/utils/local-transcription.utils.ts
+++ b/apps/desktop/src/utils/local-transcription.utils.ts
@@ -6,7 +6,8 @@ export type LocalWhisperModel =
   | "small"
   | "medium"
   | "large"
-  | "turbo";
+  | "turbo"
+  | "hindi2hinglish";
 
 export const DEFAULT_LOCAL_WHISPER_MODEL: LocalWhisperModel = "tiny";
 export const LOCAL_WHISPER_MODELS: LocalWhisperModel[] = [
@@ -16,6 +17,7 @@ export const LOCAL_WHISPER_MODELS: LocalWhisperModel[] = [
   "medium",
   "turbo",
   "large",
+  "hindi2hinglish",
 ];
 
 export const normalizeLocalWhisperModel = (
@@ -50,6 +52,15 @@ export const normalizeLocalWhisperModel = (
     normalized === "large-v3-turbo"
   ) {
     return "turbo";
+  }
+
+  if (
+    normalized === "hindi2hinglish" ||
+    normalized === "hindi-hinglish" ||
+    normalized === "hindi2hinglish-apex" ||
+    normalized === "whisper-hindi2hinglish-apex"
+  ) {
+    return "hindi2hinglish";
   }
 
   return DEFAULT_LOCAL_WHISPER_MODEL;

--- a/packages/rust_transcription/src/models.rs
+++ b/packages/rust_transcription/src/models.rs
@@ -14,6 +14,13 @@ pub enum WhisperModel {
         alias = "large-v3-turbo"
     )]
     Turbo,
+    #[serde(
+        rename = "hindi2hinglish",
+        alias = "hindi-hinglish",
+        alias = "hindi2hinglish-apex",
+        alias = "whisper-hindi2hinglish-apex"
+    )]
+    Hindi2Hinglish,
 }
 
 impl WhisperModel {
@@ -25,6 +32,10 @@ impl WhisperModel {
             "medium" => Some(Self::Medium),
             "large" => Some(Self::Large),
             "turbo" | "large-turbo" | "large_v3_turbo" | "large-v3-turbo" => Some(Self::Turbo),
+            "hindi2hinglish"
+            | "hindi-hinglish"
+            | "hindi2hinglish-apex"
+            | "whisper-hindi2hinglish-apex" => Some(Self::Hindi2Hinglish),
             _ => None,
         }
     }
@@ -37,6 +48,7 @@ impl WhisperModel {
             Self::Medium => "medium",
             Self::Large => "large",
             Self::Turbo => "turbo",
+            Self::Hindi2Hinglish => "hindi2hinglish",
         }
     }
 
@@ -48,6 +60,7 @@ impl WhisperModel {
             Self::Medium => "ggml-medium.bin",
             Self::Large => "ggml-large-v3.bin",
             Self::Turbo => "ggml-large-v3-turbo.bin",
+            Self::Hindi2Hinglish => "ggml-hindi2hinglish-apex-q5_1.bin",
         }
     }
 
@@ -79,11 +92,22 @@ impl WhisperModel {
             Self::Turbo => {
                 "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-large-v3-turbo.bin"
             }
+            Self::Hindi2Hinglish => {
+                "https://huggingface.co/voquill/whisper-hindi2hinglish-apex-ggml/resolve/main/ggml-hindi2hinglish-apex-q5_1.bin"
+            }
         }
         .to_string()
     }
 
     pub fn supported() -> &'static [&'static str] {
-        &["tiny", "base", "small", "medium", "large", "turbo"]
+        &[
+            "tiny",
+            "base",
+            "small",
+            "medium",
+            "large",
+            "turbo",
+            "hindi2hinglish",
+        ]
     }
 }


### PR DESCRIPTION
## What changed?

Added support for Hindi speech transcription with Hinglish (Latin script) output. This includes:

- New `hindi2hinglish` model option in the AI transcription configuration
- Model file: `ggml-hindi2hinglish-apex-q5_1.bin` (595 MB)
- Support for transcribing Hindi speech and converting it to Hinglish text
- Integration with the existing Whisper model infrastructure

## How is it tested?

- [x] Manual verification
- [ ] Automated tests
- [ ] Code inspection

Manual testing confirmed the model downloads correctly and transcribes Hindi audio to Hinglish text as expected.