### PR TITLE
[draft] fix: make desktop post-process budgets explicit

### DIFF
--- a/apps/desktop/src/actions/transcribe.actions.ts
+++ b/apps/desktop/src/actions/transcribe.actions.ts
@@ -27,11 +27,9 @@ import {
 import { getLogger } from "../utils/log.utils";
 import {
   buildLocalizedTranscriptionPrompt,
-  buildPostProcessingPrompt,
-  buildSystemPostProcessingTonePrompt,
+  buildPostProcessingGenerateTextInput,
   collectDictionaryEntries,
   PostProcessingPromptInput,
-  PROCESSED_TRANSCRIPTION_JSON_SCHEMA,
   PROCESSED_TRANSCRIPTION_SCHEMA,
 } from "../utils/prompt.utils";
 import { getToneById, getToneConfig } from "../utils/tone.utils";
@@ -219,26 +217,22 @@ export const postProcessTranscript = async ({
       dictationLanguage,
       tone: toneConfig,
     };
-    const ppSystem = buildSystemPostProcessingTonePrompt(promptInput);
-    const ppPrompt = buildPostProcessingPrompt(promptInput);
+    const postProcessingGenerateTextInput =
+      buildPostProcessingGenerateTextInput(promptInput);
     getLogger().verbose(
       "Post-process prompt length:",
-      ppPrompt.length,
+      postProcessingGenerateTextInput.prompt.length,
       "system length:",
-      ppSystem.length,
+      postProcessingGenerateTextInput.system.length,
+    );
+    getLogger().verbose(
+      "Post-process output budget:",
+      postProcessingGenerateTextInput.maxOutputTokens,
     );
 
     const postprocessStart = performance.now();
     getLogger().verbose("Calling LLM for post-processing");
-    const genOutput = await genRepo.generateText({
-      system: ppSystem,
-      prompt: ppPrompt,
-      jsonResponse: {
-        name: "transcription_cleaning",
-        description: "JSON response with the processed transcription",
-        schema: PROCESSED_TRANSCRIPTION_JSON_SCHEMA,
-      },
-    });
+    const genOutput = await genRepo.generateText(postProcessingGenerateTextInput);
     const postprocessDuration = performance.now() - postprocessStart;
     metadata.postprocessDurationMs = Math.round(postprocessDuration);
 
@@ -277,7 +271,7 @@ export const postProcessTranscript = async ({
       );
     }
 
-    metadata.postProcessPrompt = ppPrompt;
+    metadata.postProcessPrompt = postProcessingGenerateTextInput.prompt;
     metadata.postProcessApiKeyId = genApiKeyId;
     metadata.postProcessMode = genOutput.metadata?.postProcessingMode || null;
     metadata.postProcessDevice = genOutput.metadata?.inferenceDevice || null;

--- a/apps/desktop/src/repos/generate-text.repo.test.ts
+++ b/apps/desktop/src/repos/generate-text.repo.test.ts
@@ -1,0 +1,135 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  GeminiGenerateTextRepo,
+  GroqGenerateTextRepo,
+  OpenAIGenerateTextRepo,
+  OpenRouterGenerateTextRepo,
+} from "./generate-text.repo";
+
+const {
+  groqGenerateTextResponse,
+  openaiGenerateTextResponse,
+  openrouterGenerateTextResponse,
+  geminiGenerateTextResponse,
+} = vi.hoisted(() => ({
+  groqGenerateTextResponse: vi.fn(),
+  openaiGenerateTextResponse: vi.fn(),
+  openrouterGenerateTextResponse: vi.fn(),
+  geminiGenerateTextResponse: vi.fn(),
+}));
+
+vi.mock("@voquill/voice-ai", async () => {
+  const actual =
+    await vi.importActual<typeof import("@voquill/voice-ai")>(
+      "@voquill/voice-ai",
+    );
+  return {
+    ...actual,
+    groqGenerateTextResponse,
+    openaiGenerateTextResponse,
+    openrouterGenerateTextResponse,
+    geminiGenerateTextResponse,
+  };
+});
+
+const JSON_RESPONSE = {
+  name: "transcription_cleaning",
+  description: "JSON response with the processed transcription",
+  schema: {
+    type: "object",
+    properties: {
+      result: {
+        type: "string",
+      },
+    },
+    required: ["result"],
+  },
+};
+
+describe("generate text repos", () => {
+  beforeEach(() => {
+    groqGenerateTextResponse.mockReset().mockResolvedValue({
+      text: "{}",
+      tokensUsed: 1,
+    });
+    openaiGenerateTextResponse.mockReset().mockResolvedValue({
+      text: "{}",
+      tokensUsed: 1,
+    });
+    openrouterGenerateTextResponse.mockReset().mockResolvedValue({
+      text: "{}",
+      tokensUsed: 1,
+    });
+    geminiGenerateTextResponse.mockReset().mockResolvedValue({
+      text: "{}",
+      tokensUsed: 1,
+    });
+  });
+
+  it("forwards maxOutputTokens to the Groq helper", async () => {
+    const repo = new GroqGenerateTextRepo("test-key", "openai/gpt-oss-20b");
+
+    await repo.generateText({
+      prompt: "hello",
+      jsonResponse: JSON_RESPONSE,
+      maxOutputTokens: 256,
+    });
+
+    expect(groqGenerateTextResponse).toHaveBeenCalledWith(
+      expect.objectContaining({
+        maxOutputTokens: 256,
+      }),
+    );
+  });
+
+  it("forwards maxOutputTokens to the OpenAI helper", async () => {
+    const repo = new OpenAIGenerateTextRepo("test-key", "gpt-4o-mini");
+
+    await repo.generateText({
+      prompt: "hello",
+      jsonResponse: JSON_RESPONSE,
+      maxOutputTokens: 256,
+    });
+
+    expect(openaiGenerateTextResponse).toHaveBeenCalledWith(
+      expect.objectContaining({
+        maxOutputTokens: 256,
+      }),
+    );
+  });
+
+  it("forwards maxOutputTokens to the OpenRouter helper", async () => {
+    const repo = new OpenRouterGenerateTextRepo(
+      "test-key",
+      "openai/gpt-oss-20b",
+    );
+
+    await repo.generateText({
+      prompt: "hello",
+      jsonResponse: JSON_RESPONSE,
+      maxOutputTokens: 256,
+    });
+
+    expect(openrouterGenerateTextResponse).toHaveBeenCalledWith(
+      expect.objectContaining({
+        maxOutputTokens: 256,
+      }),
+    );
+  });
+
+  it("forwards maxOutputTokens to the Gemini helper", async () => {
+    const repo = new GeminiGenerateTextRepo("test-key", "gemini-2.5-flash");
+
+    await repo.generateText({
+      prompt: "hello",
+      jsonResponse: JSON_RESPONSE,
+      maxOutputTokens: 256,
+    });
+
+    expect(geminiGenerateTextResponse).toHaveBeenCalledWith(
+      expect.objectContaining({
+        maxOutputTokens: 256,
+      }),
+    );
+  });
+});

--- a/apps/desktop/src/repos/generate-text.repo.ts
+++ b/apps/desktop/src/repos/generate-text.repo.ts
@@ -44,6 +44,7 @@ export type GenerateTextInput = {
   system?: Nullable<string>;
   prompt: string;
   jsonResponse?: JsonResponse;
+  maxOutputTokens?: number;
 };
 
 export type GenerateTextMetadata = {
@@ -112,6 +113,7 @@ export class GroqGenerateTextRepo extends BaseGenerateTextRepo {
       prompt: input.prompt,
       system: input.system ?? undefined,
       jsonResponse: input.jsonResponse,
+      maxOutputTokens: input.maxOutputTokens,
     });
 
     return {
@@ -149,6 +151,7 @@ export class OpenAIGenerateTextRepo extends BaseGenerateTextRepo {
       prompt: input.prompt,
       system: input.system ?? undefined,
       jsonResponse: input.jsonResponse,
+      maxOutputTokens: input.maxOutputTokens,
     });
 
     return {
@@ -189,6 +192,7 @@ export class OllamaGenerateTextRepo extends BaseGenerateTextRepo {
       prompt: input.prompt,
       system: input.system ?? undefined,
       jsonResponse: input.jsonResponse,
+      maxOutputTokens: input.maxOutputTokens,
       customFetch: tauriFetch,
     });
 
@@ -232,6 +236,7 @@ export class OpenAICompatibleGenerateTextRepo extends BaseGenerateTextRepo {
       prompt: input.prompt,
       system: input.system ?? undefined,
       jsonResponse: input.jsonResponse,
+      maxOutputTokens: input.maxOutputTokens,
       customFetch: tauriFetch,
     });
 
@@ -278,6 +283,7 @@ export class OpenRouterGenerateTextRepo extends BaseGenerateTextRepo {
       prompt: input.prompt,
       system: input.system ?? undefined,
       jsonResponse: input.jsonResponse,
+      maxOutputTokens: input.maxOutputTokens,
       providerRouting: this.providerRouting,
     });
 
@@ -319,6 +325,7 @@ export class AzureOpenAIGenerateTextRepo extends BaseGenerateTextRepo {
       system: input.system ?? undefined,
       prompt: input.prompt,
       jsonResponse: input.jsonResponse,
+      maxOutputTokens: input.maxOutputTokens,
     });
 
     return {
@@ -357,6 +364,7 @@ export class DeepseekGenerateTextRepo extends BaseGenerateTextRepo {
       prompt: input.prompt,
       system: input.system ?? undefined,
       jsonResponse: input.jsonResponse,
+      maxOutputTokens: input.maxOutputTokens,
     });
 
     return {
@@ -394,6 +402,7 @@ export class GeminiGenerateTextRepo extends BaseGenerateTextRepo {
       prompt: input.prompt,
       system: input.system ?? undefined,
       jsonResponse: input.jsonResponse,
+      maxOutputTokens: input.maxOutputTokens,
     });
 
     return {
@@ -431,6 +440,7 @@ export class ClaudeGenerateTextRepo extends BaseGenerateTextRepo {
       prompt: input.prompt,
       system: input.system ?? undefined,
       jsonResponse: input.jsonResponse,
+      maxOutputTokens: input.maxOutputTokens,
     });
 
     return {
@@ -468,6 +478,7 @@ export class CerebrasGenerateTextRepo extends BaseGenerateTextRepo {
       prompt: input.prompt,
       system: input.system ?? undefined,
       jsonResponse: input.jsonResponse,
+      maxOutputTokens: input.maxOutputTokens,
     });
 
     return {

--- a/apps/desktop/src/utils/prompt.utils.test.ts
+++ b/apps/desktop/src/utils/prompt.utils.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
 import {
   buildPostProcessingPrompt,
+  buildPostProcessingGenerateTextInput,
   buildSystemPostProcessingTonePrompt,
+  POST_PROCESS_MAX_OUTPUT_TOKENS,
   PostProcessingPromptInput,
 } from "./prompt.utils";
 import { StyleToneConfig, TemplateToneConfig } from "./tone.utils";
@@ -98,5 +100,23 @@ describe("buildPostProcessingPrompt", () => {
     expect(result).toContain(
       "Process the transcript according to the instructions",
     );
+  });
+});
+
+describe("buildPostProcessingGenerateTextInput", () => {
+  it("builds the transcript-cleanup request with an explicit output budget", () => {
+    const result = buildPostProcessingGenerateTextInput(
+      makeInput({ kind: "style", stylePrompt: "Be formal" }),
+    );
+
+    expect(result).toMatchObject({
+      maxOutputTokens: POST_PROCESS_MAX_OUTPUT_TOKENS,
+      jsonResponse: {
+        name: "transcription_cleaning",
+        description: "JSON response with the processed transcription",
+      },
+    });
+    expect(result.system).toContain("Be formal");
+    expect(result.prompt).toContain("Hello world");
   });
 });

--- a/apps/desktop/src/utils/prompt.utils.ts
+++ b/apps/desktop/src/utils/prompt.utils.ts
@@ -296,9 +296,11 @@ Here is the transcript:
 ${transcript}
 </transcript>
 
-Process the transcript according to the instructions.
-`.trim();
+  Process the transcript according to the instructions.
+  `.trim();
 };
+
+export const POST_PROCESS_MAX_OUTPUT_TOKENS = 1024;
 
 export const PROCESSED_TRANSCRIPTION_SCHEMA = z.object({
   result: z.string().describe("The processed transcription"),
@@ -307,6 +309,19 @@ export const PROCESSED_TRANSCRIPTION_SCHEMA = z.object({
 export const PROCESSED_TRANSCRIPTION_JSON_SCHEMA =
   zodToJsonSchema(PROCESSED_TRANSCRIPTION_SCHEMA, "Schema").definitions
     ?.Schema ?? {};
+
+export const buildPostProcessingGenerateTextInput = (
+  input: PostProcessingPromptInput,
+) => ({
+  system: buildSystemPostProcessingTonePrompt(input),
+  prompt: buildPostProcessingPrompt(input),
+  jsonResponse: {
+    name: "transcription_cleaning",
+    description: "JSON response with the processed transcription",
+    schema: PROCESSED_TRANSCRIPTION_JSON_SCHEMA,
+  },
+  maxOutputTokens: POST_PROCESS_MAX_OUTPUT_TOKENS,
+});
 
 export const buildSystemAgentPrompt = (): string => {
   return "You are a helpful AI assistant that executes user commands. The user will dictate instructions via voice, and you will execute those instructions and return the output. Your job is to understand what the user wants and produce it. Examples: 'write a poem about cats' → write the poem; 'summarize this article' → provide the summary; 'create a shopping list' → create the list; 'draft an email to my boss' → draft the email. Always return just the requested output, ready to be pasted.";

--- a/packages/voice-ai/src/azure-openai.utils.ts
+++ b/packages/voice-ai/src/azure-openai.utils.ts
@@ -21,6 +21,7 @@ export type AzureOpenAIGenerateTextArgs = {
   system?: string;
   prompt: string;
   jsonResponse?: JsonResponse;
+  maxOutputTokens?: number;
 };
 
 export type AzureOpenAIGenerateResponseOutput = {
@@ -44,6 +45,7 @@ export const azureOpenAIGenerateText = async ({
   system,
   prompt,
   jsonResponse,
+  maxOutputTokens,
 }: AzureOpenAIGenerateTextArgs): Promise<AzureOpenAIGenerateResponseOutput> => {
   return retry({
     retries: 3,
@@ -60,7 +62,7 @@ export const azureOpenAIGenerateText = async ({
         messages,
         model: deploymentName,
         temperature: 1,
-        max_completion_tokens: 1024,
+        max_completion_tokens: maxOutputTokens ?? 1024,
         response_format: jsonResponse
           ? {
               type: "json_schema",

--- a/packages/voice-ai/src/cerebras.utils.ts
+++ b/packages/voice-ai/src/cerebras.utils.ts
@@ -53,6 +53,7 @@ export type CerebrasGenerateTextArgs = {
   system?: string;
   prompt: string;
   jsonResponse?: JsonResponse;
+  maxOutputTokens?: number;
 };
 
 export type CerebrasGenerateResponseOutput = {
@@ -66,6 +67,7 @@ export const cerebrasGenerateTextResponse = async ({
   system,
   prompt,
   jsonResponse,
+  maxOutputTokens,
 }: CerebrasGenerateTextArgs): Promise<CerebrasGenerateResponseOutput> => {
   return retry({
     retries: 3,
@@ -90,7 +92,7 @@ export const cerebrasGenerateTextResponse = async ({
         messages,
         model,
         temperature: 1,
-        max_tokens: 1024,
+        max_tokens: maxOutputTokens ?? 1024,
         top_p: 1,
         response_format: jsonResponse ? { type: "json_object" } : undefined,
       };

--- a/packages/voice-ai/src/claude.utils.ts
+++ b/packages/voice-ai/src/claude.utils.ts
@@ -53,6 +53,7 @@ export type ClaudeGenerateTextArgs = {
   system?: string;
   prompt: string;
   jsonResponse?: JsonResponse;
+  maxOutputTokens?: number;
 };
 
 export type ClaudeGenerateResponseOutput = {
@@ -66,6 +67,7 @@ export const claudeGenerateTextResponse = async ({
   system,
   prompt,
   jsonResponse,
+  maxOutputTokens,
 }: ClaudeGenerateTextArgs): Promise<ClaudeGenerateResponseOutput> => {
   return retry({
     retries: 3,
@@ -79,7 +81,7 @@ export const claudeGenerateTextResponse = async ({
 
       const response = await client.messages.create({
         model,
-        max_tokens: 1024,
+        max_tokens: maxOutputTokens ?? 1024,
         system: system ?? undefined,
         messages: [{ role: "user", content: finalPrompt }],
       });

--- a/packages/voice-ai/src/deepseek.utils.ts
+++ b/packages/voice-ai/src/deepseek.utils.ts
@@ -48,6 +48,7 @@ export type DeepseekGenerateTextArgs = {
   system?: string;
   prompt: string;
   jsonResponse?: JsonResponse;
+  maxOutputTokens?: number;
 };
 
 export type DeepseekGenerateResponseOutput = {
@@ -61,6 +62,7 @@ export const deepseekGenerateTextResponse = async ({
   system,
   prompt,
   jsonResponse,
+  maxOutputTokens,
 }: DeepseekGenerateTextArgs): Promise<DeepseekGenerateResponseOutput> => {
   return retry({
     retries: 3,
@@ -85,7 +87,7 @@ export const deepseekGenerateTextResponse = async ({
         messages,
         model,
         temperature: 1,
-        max_tokens: 1024,
+        max_tokens: maxOutputTokens ?? 1024,
         top_p: 1,
         response_format: jsonResponse ? { type: "json_object" } : undefined,
       });

--- a/packages/voice-ai/src/gemini.utils.ts
+++ b/packages/voice-ai/src/gemini.utils.ts
@@ -149,6 +149,7 @@ export type GeminiGenerateTextArgs = {
   system?: string;
   prompt: string;
   jsonResponse?: JsonResponse;
+  maxOutputTokens?: number;
 };
 
 export type GeminiGenerateResponseOutput = {
@@ -162,6 +163,7 @@ export const geminiGenerateTextResponse = async ({
   system,
   prompt,
   jsonResponse,
+  maxOutputTokens,
 }: GeminiGenerateTextArgs): Promise<GeminiGenerateResponseOutput> => {
   return retry({
     retries: 3,
@@ -174,6 +176,9 @@ export const geminiGenerateTextResponse = async ({
       }
 
       const config: Record<string, unknown> = {};
+      if (maxOutputTokens != null) {
+        config.maxOutputTokens = maxOutputTokens;
+      }
       if (jsonResponse) {
         config.responseMimeType = "application/json";
         if (jsonResponse.schema) {

--- a/packages/voice-ai/src/groq.utils.ts
+++ b/packages/voice-ai/src/groq.utils.ts
@@ -113,6 +113,7 @@ export type GroqGenerateTextArgs = {
   prompt: string;
   imageUrls?: string[];
   jsonResponse?: JsonResponse;
+  maxOutputTokens?: number;
 };
 
 export type GroqGenerateResponseOutput = {
@@ -127,6 +128,7 @@ export const groqGenerateTextResponse = async ({
   prompt,
   imageUrls = [],
   jsonResponse,
+  maxOutputTokens,
 }: GroqGenerateTextArgs): Promise<GroqGenerateResponseOutput> => {
   return retry({
     retries: 3,
@@ -152,7 +154,7 @@ export const groqGenerateTextResponse = async ({
       const response = await client.chat.completions.create({
         messages,
         model,
-        max_completion_tokens: 8192,
+        max_completion_tokens: maxOutputTokens ?? 1024,
         response_format: jsonResponse
           ? JSON_SCHEMA_SUPPORTED_MODELS.has(model)
             ? {

--- a/packages/voice-ai/src/openai.utils.ts
+++ b/packages/voice-ai/src/openai.utils.ts
@@ -122,6 +122,7 @@ export type OpenAIGenerateTextArgs = {
   prompt: string;
   imageUrls?: string[];
   jsonResponse?: JsonResponse;
+  maxOutputTokens?: number;
   customFetch?: CustomFetch;
 };
 
@@ -138,6 +139,7 @@ export const openaiGenerateTextResponse = async ({
   prompt,
   imageUrls = [],
   jsonResponse,
+  maxOutputTokens,
   customFetch,
 }: OpenAIGenerateTextArgs): Promise<OpenAIGenerateResponseOutput> => {
   return retry({
@@ -165,7 +167,7 @@ export const openaiGenerateTextResponse = async ({
         messages,
         model,
         temperature: 1,
-        max_completion_tokens: 1024,
+        max_completion_tokens: maxOutputTokens ?? 1024,
         top_p: 1,
         response_format: jsonResponse
           ? {

--- a/packages/voice-ai/src/openrouter.utils.ts
+++ b/packages/voice-ai/src/openrouter.utils.ts
@@ -136,6 +136,7 @@ export type OpenRouterGenerateTextArgs = {
   system?: string;
   prompt: string;
   jsonResponse?: JsonResponse;
+  maxOutputTokens?: number;
   providerRouting?: OpenRouterProviderRouting;
   customFetch?: CustomFetch;
 };
@@ -155,6 +156,7 @@ export const openrouterGenerateTextResponse = async ({
   system,
   prompt,
   jsonResponse,
+  maxOutputTokens,
   providerRouting,
   customFetch,
 }: OpenRouterGenerateTextArgs): Promise<OpenRouterGenerateTextOutput> => {
@@ -176,7 +178,7 @@ export const openrouterGenerateTextResponse = async ({
         messages,
         model,
         temperature: 1,
-        max_tokens: 1024,
+        max_tokens: maxOutputTokens ?? 1024,
         top_p: 1,
         response_format: jsonResponse
           ? {

--- a/packages/voice-ai/test/output-budget-overrides.test.ts
+++ b/packages/voice-ai/test/output-budget-overrides.test.ts
@@ -1,0 +1,163 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+describe("generate text helper output budgets", () => {
+  afterEach(() => {
+    vi.resetModules();
+    vi.doUnmock("groq-sdk/index");
+    vi.doUnmock("openai");
+    vi.doUnmock("@google/genai");
+  });
+
+  it("uses the safer Groq default budget when no override is provided", async () => {
+    const createCompletion = vi.fn().mockResolvedValue({
+      choices: [
+        {
+          message: {
+            content: JSON.stringify({ result: "Hello there" }),
+          },
+        },
+      ],
+      usage: {
+        total_tokens: 42,
+      },
+    });
+
+    vi.doMock("groq-sdk/index", () => ({
+      default: class MockGroq {
+        chat = {
+          completions: {
+            create: createCompletion,
+          },
+        };
+      },
+      toFile: vi.fn(),
+    }));
+
+    const { groqGenerateTextResponse } = await import("../src/groq.utils");
+
+    await groqGenerateTextResponse({
+      apiKey: "test-key",
+      prompt: "hello there",
+    });
+
+    expect(createCompletion.mock.calls[0][0]).toMatchObject({
+      max_completion_tokens: 1024,
+    });
+  });
+
+  it("passes the override through to Groq", async () => {
+    const createCompletion = vi.fn().mockResolvedValue({
+      choices: [
+        {
+          message: {
+            content: JSON.stringify({ result: "Hello there" }),
+          },
+        },
+      ],
+      usage: {
+        total_tokens: 42,
+      },
+    });
+
+    vi.doMock("groq-sdk/index", () => ({
+      default: class MockGroq {
+        chat = {
+          completions: {
+            create: createCompletion,
+          },
+        };
+      },
+      toFile: vi.fn(),
+    }));
+
+    const { groqGenerateTextResponse } = await import("../src/groq.utils");
+
+    await groqGenerateTextResponse({
+      apiKey: "test-key",
+      prompt: "hello there",
+      maxOutputTokens: 256,
+    });
+
+    expect(createCompletion.mock.calls[0][0]).toMatchObject({
+      max_completion_tokens: 256,
+    });
+  });
+
+  it("passes the override through to OpenRouter", async () => {
+    const createCompletion = vi.fn().mockResolvedValue({
+      choices: [
+        {
+          message: {
+            content: JSON.stringify({ result: "Hello there" }),
+          },
+        },
+      ],
+      usage: {
+        total_tokens: 42,
+      },
+    });
+
+    vi.doMock("openai", () => ({
+      default: class MockOpenAI {
+        chat = {
+          completions: {
+            create: createCompletion,
+          },
+        };
+      },
+    }));
+
+    const { openrouterGenerateTextResponse } = await import(
+      "../src/openrouter.utils"
+    );
+
+    await openrouterGenerateTextResponse({
+      apiKey: "test-key",
+      prompt: "hello there",
+      maxOutputTokens: 256,
+    });
+
+    expect(createCompletion.mock.calls[0][0]).toMatchObject({
+      max_tokens: 256,
+    });
+  });
+
+  it("passes the override through to Gemini", async () => {
+    const generateContent = vi.fn().mockResolvedValue({
+      text: '{"result":"Hello there"}',
+      usageMetadata: {
+        totalTokenCount: 42,
+      },
+    });
+
+    vi.doMock("@google/genai", () => ({
+      GoogleGenAI: class MockGoogleGenAI {
+        models = {
+          generateContent,
+        };
+      },
+      Type: {
+        OBJECT: "object",
+        ARRAY: "array",
+        STRING: "string",
+        NUMBER: "number",
+        INTEGER: "integer",
+        BOOLEAN: "boolean",
+      },
+    }));
+
+    const { geminiGenerateTextResponse } = await import("../src/gemini.utils");
+
+    await geminiGenerateTextResponse({
+      apiKey: "test-key",
+      prompt: "hello there",
+      maxOutputTokens: 256,
+    });
+
+    expect(generateContent.mock.calls[0][0]).toMatchObject({
+      config: expect.objectContaining({
+        maxOutputTokens: 256,
+      }),
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add an explicit `maxOutputTokens` field to the desktop generate-text contract and use it for transcript post-processing
- thread that budget through the desktop BYOK/API repos into provider-native request parameters
- keep the branch self-contained by preserving the safer Groq 1024 default and adding regression coverage

Closes #420

## Testing
- apps/desktop/node_modules/.bin/vitest run apps/desktop/src/utils/prompt.utils.test.ts --root .
- apps/desktop/node_modules/.bin/vitest run apps/desktop/src/repos/generate-text.repo.test.ts --root .
- apps/desktop/node_modules/.bin/vitest run packages/voice-ai/test/output-budget-overrides.test.ts --root .
- npx --yes pnpm --filter @voquill/voice-ai build
- npx --yes pnpm --filter @repo/agent build
- npx --yes pnpm --filter @voquill/pricing build
- npx --yes pnpm --filter desktop build