### PR TITLE
support idle timeout

### DIFF
--- a/apps/desktop/src/sidecars/base.sidecar.ts
+++ b/apps/desktop/src/sidecars/base.sidecar.ts
@@ -15,6 +15,7 @@ export type SidecarConfig = {
   healthTimeoutMs: number;
   healthPollIntervalMs: number;
   logPrefix: string;
+  idleDisposeMs?: number;
 };
 
 export type SidecarRuntime = {
@@ -27,10 +28,13 @@ export abstract class BaseSidecar {
   private runtime: SidecarRuntime | null = null;
   private startupPromise: Promise<SidecarRuntime> | null = null;
   private stoppingPid: number | null = null;
+  private idleTimer: ReturnType<typeof setTimeout> | null = null;
 
   constructor(protected readonly config: SidecarConfig) {}
 
   async ensureStarted(): Promise<SidecarRuntime> {
+    this.cancelIdleTimer();
+
     if (this.runtime) {
       return this.runtime;
     }
@@ -56,6 +60,7 @@ export abstract class BaseSidecar {
   }
 
   async dispose(): Promise<void> {
+    this.cancelIdleTimer();
     const runtime = this.runtime;
     this.runtime = null;
 
@@ -87,10 +92,37 @@ export abstract class BaseSidecar {
   }
 
   protected async resetRuntime(): Promise<void> {
+    this.cancelIdleTimer();
     const runtime = this.runtime;
     this.runtime = null;
     if (runtime) {
       await runtime.child.kill().catch(() => {});
+    }
+  }
+
+  protected markActivity(): void {
+    if (this.config.idleDisposeMs == null || !this.runtime) {
+      return;
+    }
+
+    this.cancelIdleTimer();
+    this.idleTimer = setTimeout(() => {
+      this.idleTimer = null;
+      getLogger().info(
+        `[${this.config.logPrefix}] idle for ${this.config.idleDisposeMs}ms, disposing to free resources`,
+      );
+      void this.dispose().catch((error) => {
+        getLogger().warning(
+          `[${this.config.logPrefix}] idle dispose failed: ${toErrorMessage(error)}`,
+        );
+      });
+    }, this.config.idleDisposeMs);
+  }
+
+  private cancelIdleTimer(): void {
+    if (this.idleTimer !== null) {
+      clearTimeout(this.idleTimer);
+      this.idleTimer = null;
     }
   }
 

--- a/apps/desktop/src/sidecars/local-transcription.sidecar.ts
+++ b/apps/desktop/src/sidecars/local-transcription.sidecar.ts
@@ -105,6 +105,7 @@ const SIDECAR_REQUEST_RETRY_DELAY_MS = 250;
 const MODEL_DOWNLOAD_TIMEOUT_MS = 45 * 60 * 1_000;
 const MODEL_DOWNLOAD_POLL_INTERVAL_MS = 500;
 const SIDECAR_UPLOAD_CHUNK_SAMPLE_COUNT = 16_000;
+const SIDECAR_IDLE_DISPOSE_MS = 60_000;
 
 export class SidecarRequestError extends Error {
   status?: number;
@@ -136,6 +137,7 @@ export class LocalTranscriptionSidecar extends BaseSidecar {
       healthTimeoutMs: 2_000,
       healthPollIntervalMs: 150,
       logPrefix: `local-sidecar:${mode}`,
+      idleDisposeMs: SIDECAR_IDLE_DISPOSE_MS,
     });
 
     this.mode = mode;
@@ -590,11 +592,13 @@ export class LocalTranscriptionSidecar extends BaseSidecar {
     for (let attempt = 1; attempt <= retries; attempt += 1) {
       const runtime = await this.ensureStarted();
       try {
-        return await this.requestJsonByUrl<T>(runtime.baseUrl, path, {
+        const result = await this.requestJsonByUrl<T>(runtime.baseUrl, path, {
           init,
           timeoutMs,
           retries: 1,
         });
+        this.markActivity();
+        return result;
       } catch (error) {
         lastError = error;
         const isTransport = this.isTransportError(error);


### PR DESCRIPTION
## What changed?

Added `idleDisposeMs` optional configuration to sidecar runtime, enabling automatic disposal of idle sidecars after a configurable timeout. Updated `BaseSidecar` to manage an idle timer and added disposal logic. Adjusted `LocalTranscriptionSidecar` defaults to use the new idle timeout (60 seconds). Updated related documentation and comments.

<!-- Demo video/screenshots -->

*No demo video available; the change is internal behavior.*

## How is it tested?

- [ ] Automated tests
- [x] Manual verification
- [x] Code inspection

Manual verification was performed by running the application with the new idle timeout and confirming that idle sidecars are disposed after the specified period without affecting active processes. Code inspection ensured proper handling of the new timer and error cases.

Closes #423 