### PR TITLE
Add support for GPT-4o Transcribe and GPT-4o Mini Transcribe

### DIFF
--- a/apps/desktop/src-tauri/src/platform/macos/accessibility.rs
+++ b/apps/desktop/src-tauri/src/platform/macos/accessibility.rs
@@ -1204,7 +1204,7 @@ unsafe fn dump_element_children(
         lines.push(format_element_line(child, depth, i));
         *element_count += 1;
 
-        if depth + 1 <= DUMP_MAX_DEPTH {
+        if depth < DUMP_MAX_DEPTH {
             dump_element_children(child, depth + 1, lines, element_count);
         }
     }
@@ -1908,7 +1908,7 @@ unsafe fn resolve_element(
                             "RESOLVE: depth {depth}: sibling [{i}] score={score} {}",
                             snapshot_element("", candidate)
                         ));
-                        if best.map_or(true, |(s, _)| score > s) {
+                        if best.is_none_or(|(s, _)| score > s) {
                             best = Some((score, i));
                         }
                     }
@@ -2482,9 +2482,7 @@ pub fn capture_app_identity(pid: i32) -> Option<crate::commands::AppIdentity> {
 
         let _: () = msg_send![pool, drain];
 
-        if bundle_id.is_none() {
-            return None;
-        }
+        bundle_id.as_ref()?;
 
         Some(crate::commands::AppIdentity {
             exe_path: None,

--- a/apps/desktop/src/components/settings/api-key-provider-config.tsx
+++ b/apps/desktop/src/components/settings/api-key-provider-config.tsx
@@ -151,7 +151,7 @@ function getOpenAICompatibleConfig(
       label: <FormattedMessage defaultMessage="Model" />,
       placeholder: "whisper-1",
       helperText: (
-        <FormattedMessage defaultMessage="Transcription model name (e.g. whisper-1)" />
+        <FormattedMessage defaultMessage="Transcription model name (e.g. whisper-1, gpt-4o-transcribe)" />
       ),
       required: false,
     });

--- a/apps/desktop/src/repos/model-provider.repo.ts
+++ b/apps/desktop/src/repos/model-provider.repo.ts
@@ -54,6 +54,10 @@ function isWhisperModel(modelId: string): boolean {
   return modelId.includes("whisper");
 }
 
+function isOpenAITranscriptionModel(modelId: string): boolean {
+  return isWhisperModel(modelId) || modelId.includes("transcribe");
+}
+
 function filterFetchedModels(
   fetched: string[],
   allowList: readonly string[],
@@ -115,12 +119,12 @@ export class OpenAIModelProviderRepo extends BaseModelProviderRepo {
     options: FetchModelsOptions,
   ): Promise<string[]> {
     const fetched = await this.fetchModels(options);
-    return fetched.filter((m) => !isWhisperModel(m));
+    return fetched.filter((m) => !isOpenAITranscriptionModel(m));
   }
 
   async getTranscriptionModels(options: FetchModelsOptions): Promise<string[]> {
     const fetched = await this.fetchModels(options);
-    return fetched.filter(isWhisperModel);
+    return fetched.filter(isOpenAITranscriptionModel);
   }
 }
 

--- a/packages/voice-ai/src/openai.utils.ts
+++ b/packages/voice-ai/src/openai.utils.ts
@@ -28,7 +28,11 @@ export const OPENAI_GENERATE_TEXT_MODELS = [
 export type OpenAIGenerateTextModel =
   (typeof OPENAI_GENERATE_TEXT_MODELS)[number];
 
-export const OPENAI_TRANSCRIPTION_MODELS = ["whisper-1"] as const;
+export const OPENAI_TRANSCRIPTION_MODELS = [
+  "whisper-1",
+  "gpt-4o-transcribe",
+  "gpt-4o-mini-transcribe",
+] as const;
 export type OpenAITranscriptionModel =
   (typeof OPENAI_TRANSCRIPTION_MODELS)[number];
 
@@ -306,7 +310,12 @@ function llmToolsToOpenAI(
 
 function llmToolChoiceToOpenAI(
   choice: LlmToolChoice | undefined,
-): "auto" | "none" | "required" | { type: "function"; function: { name: string } } | undefined {
+):
+  | "auto"
+  | "none"
+  | "required"
+  | { type: "function"; function: { name: string } }
+  | undefined {
   if (!choice) return undefined;
   if (typeof choice === "string") return choice;
   return { type: "function", function: { name: choice.name } };
@@ -378,7 +387,11 @@ export async function* openaiCompatibleStreamChat(
 
     for (const tc of choice.delta?.tool_calls ?? []) {
       const index = tc.index ?? toolCalls.size;
-      const current = toolCalls.get(index) ?? { id: "", name: "", arguments: "" };
+      const current = toolCalls.get(index) ?? {
+        id: "",
+        name: "",
+        arguments: "",
+      };
       if (tc.id) current.id = tc.id;
       if (tc.function?.name) current.name = tc.function.name;
       if (tc.function?.arguments) current.arguments += tc.function.arguments;
@@ -391,7 +404,12 @@ export async function* openaiCompatibleStreamChat(
   }
 
   for (const [, tc] of [...toolCalls.entries()].sort(([a], [b]) => a - b)) {
-    yield { type: "tool-call", id: tc.id, name: tc.name, arguments: tc.arguments };
+    yield {
+      type: "tool-call",
+      id: tc.id,
+      name: tc.name,
+      arguments: tc.arguments,
+    };
   }
 
   yield {


### PR DESCRIPTION
**Summary** - Adds support for OpenAI's GPT-4o Transcribe (\gpt-4o-transcribe\) and GPT-4o Mini Transcribe (\gpt-4o-mini-transcribe\) transcription models alongside the existing \whisper-1\.

**Changes**
- \packages/voice-ai/src/openai.utils.ts\ — Added both new models to the type union
- \pps/desktop/src/repos/model-provider.repo.ts\ — Updated model filtering to recognize GPT-4o Transcribe models
- \pps/desktop/src/components/settings/api-key-provider-config.tsx\ — Updated helper text with new model examples

No API or schema changes needed — same endpoint and response format as whisper-1.