### PR TITLE
Fix Windows dictation pill: DPI scaling and virtual desktop following

### DIFF
--- a/apps/desktop/src-tauri/src/platform/macos/accessibility.rs
+++ b/apps/desktop/src-tauri/src/platform/macos/accessibility.rs
@@ -1204,7 +1204,7 @@ unsafe fn dump_element_children(
         lines.push(format_element_line(child, depth, i));
         *element_count += 1;
 
-        if depth + 1 <= DUMP_MAX_DEPTH {
+        if depth < DUMP_MAX_DEPTH {
             dump_element_children(child, depth + 1, lines, element_count);
         }
     }
@@ -1908,7 +1908,7 @@ unsafe fn resolve_element(
                             "RESOLVE: depth {depth}: sibling [{i}] score={score} {}",
                             snapshot_element("", candidate)
                         ));
-                        if best.map_or(true, |(s, _)| score > s) {
+                        if best.is_none_or(|(s, _)| score > s) {
                             best = Some((score, i));
                         }
                     }
@@ -2482,9 +2482,7 @@ pub fn capture_app_identity(pid: i32) -> Option<crate::commands::AppIdentity> {
 
         let _: () = msg_send![pool, drain];
 
-        if bundle_id.is_none() {
-            return None;
-        }
+        bundle_id.as_ref()?;
 
         Some(crate::commands::AppIdentity {
             exe_path: None,

--- a/packages/rust_windows_pill/Cargo.toml
+++ b/packages/rust_windows_pill/Cargo.toml
@@ -30,5 +30,6 @@ features = [
     "Win32_UI_Input_KeyboardAndMouse",
     "Win32_Graphics_Dwm",
     "Win32_UI_Controls",
+    "Win32_UI_Shell",
     "Win32_UI_WindowsAndMessaging",
 ]

--- a/packages/rust_windows_pill/src/draw.rs
+++ b/packages/rust_windows_pill/src/draw.rs
@@ -9,6 +9,10 @@ pub(crate) fn draw_all(gfx: &mut Gfx, state: &PillState) {
 
     state.click_regions.borrow_mut().clear();
 
+    let scale = state.ui_scale.get();
+    gfx.save();
+    gfx.scale(scale, scale);
+
     let ww = state.draw_width.get();
     let wh = state.draw_height.get();
     let (ox, oy) = state.content_offset();
@@ -53,6 +57,7 @@ pub(crate) fn draw_all(gfx: &mut Gfx, state: &PillState) {
         draw_cancel_button(gfx, state, ww, wh);
     }
 
+    gfx.restore();
     gfx.restore();
     gfx.end_frame();
 }

--- a/packages/rust_windows_pill/src/pill.rs
+++ b/packages/rust_windows_pill/src/pill.rs
@@ -6,8 +6,10 @@ use windows::core::*;
 use windows::Win32::Foundation::*;
 use windows::Win32::Graphics::Gdi::*;
 use windows::Win32::System::LibraryLoader::*;
+use windows::Win32::System::Com::{CoCreateInstance, CLSCTX_INPROC_SERVER};
 use windows::Win32::UI::HiDpi::{GetDpiForMonitor, MDT_EFFECTIVE_DPI};
 use windows::Win32::UI::Input::KeyboardAndMouse::*;
+use windows::Win32::UI::Shell::{IVirtualDesktopManager, VirtualDesktopManager};
 use windows::Win32::UI::WindowsAndMessaging::*;
 
 use crate::constants::*;
@@ -31,6 +33,7 @@ thread_local! {
     static EDIT_CONTAINER: Cell<HWND> = const { Cell::new(HWND(std::ptr::null_mut())) };
     static EDIT_HWND: Cell<HWND> = const { Cell::new(HWND(std::ptr::null_mut())) };
     static EDIT_BG_BRUSH: Cell<HBRUSH> = const { Cell::new(HBRUSH(std::ptr::null_mut())) };
+    static VDM: RefCell<Option<IVirtualDesktopManager>> = const { RefCell::new(None) };
 }
 
 fn get_dpi_scale() -> f64 {
@@ -165,6 +168,12 @@ pub fn run(receiver: Receiver<InMessage>) {
     STATE.with(|s| *s.borrow_mut() = Some(state));
     GFX.with(|g| *g.borrow_mut() = Some(gfx));
     RECEIVER.with(|r| *r.borrow_mut() = Some(receiver));
+
+    // Initialize Virtual Desktop Manager so the pill follows across desktops
+    match unsafe { CoCreateInstance(&VirtualDesktopManager, None, CLSCTX_INPROC_SERVER) } {
+        Ok(vdm) => VDM.with(|c| *c.borrow_mut() = Some(vdm)),
+        Err(e) => eprintln!("[pill] VirtualDesktopManager unavailable: {e:?}"),
+    }
 
     create_edit_overlay(hinstance, hwnd);
     eprintln!("[pill] edit overlay created in {:?}", t0.elapsed());
@@ -376,6 +385,43 @@ fn on_cursor_tick(hwnd: HWND) {
         if let Some(ref state) = *s.borrow() {
             check_hover(hwnd, state);
             reposition_to_cursor_monitor(hwnd);
+        }
+    });
+    ensure_on_current_desktop(hwnd);
+}
+
+fn ensure_on_current_desktop(hwnd: HWND) {
+    VDM.with(|v| {
+        let vdm_guard = v.borrow();
+        let vdm = match &*vdm_guard {
+            Some(ref vdm) => vdm,
+            None => return,
+        };
+        let result: windows::core::Result<windows::core::BOOL> =
+            unsafe { vdm.IsWindowOnCurrentVirtualDesktop(hwnd) };
+        if let Ok(is_on_current) = result {
+            if !is_on_current.as_bool() {
+                // Create a temporary window on the current desktop to get its GUID
+                if let Ok(temp_hwnd) = unsafe {
+                    CreateWindowExW(
+                        WS_EX_TOOLWINDOW | WS_EX_NOACTIVATE,
+                        w!("STATIC"),
+                        w!(""),
+                        WS_POPUP,
+                        0, 0, 1, 1,
+                        None, None, None, None,
+                    )
+                } {
+                    if let Ok(cur_desktop_id) =
+                        unsafe { vdm.GetWindowDesktopId(temp_hwnd) }
+                    {
+                        unsafe {
+                            let _ = vdm.MoveWindowToDesktop(hwnd, &cur_desktop_id);
+                        }
+                    }
+                    unsafe { let _ = DestroyWindow(temp_hwnd); }
+                }
+            }
         }
     });
 }

--- a/packages/rust_windows_pill/src/pill.rs
+++ b/packages/rust_windows_pill/src/pill.rs
@@ -6,6 +6,7 @@ use windows::core::*;
 use windows::Win32::Foundation::*;
 use windows::Win32::Graphics::Gdi::*;
 use windows::Win32::System::LibraryLoader::*;
+use windows::Win32::UI::HiDpi::{GetDpiForMonitor, MDT_EFFECTIVE_DPI};
 use windows::Win32::UI::Input::KeyboardAndMouse::*;
 use windows::Win32::UI::WindowsAndMessaging::*;
 
@@ -32,6 +33,20 @@ thread_local! {
     static EDIT_BG_BRUSH: Cell<HBRUSH> = const { Cell::new(HBRUSH(std::ptr::null_mut())) };
 }
 
+fn get_dpi_scale() -> f64 {
+    unsafe {
+        let mut cursor = POINT::default();
+        if GetCursorPos(&mut cursor).is_err() {
+            return 1.0;
+        }
+        let monitor = MonitorFromPoint(cursor, MONITOR_DEFAULTTOPRIMARY);
+        let mut dpi_x: u32 = 96;
+        let mut dpi_y: u32 = 96;
+        let _ = GetDpiForMonitor(monitor, MDT_EFFECTIVE_DPI, &mut dpi_x, &mut dpi_y);
+        (dpi_x as f64 / 96.0).max(1.0)
+    }
+}
+
 pub fn run(receiver: Receiver<InMessage>) {
     let t0 = Instant::now();
     unsafe {
@@ -39,6 +54,11 @@ pub fn run(receiver: Receiver<InMessage>) {
             windows::Win32::UI::HiDpi::DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2,
         );
     }
+
+    let ui_scale = get_dpi_scale();
+    let window_w = (WINDOW_W_TYPING as f64 * ui_scale) as i32;
+    let window_h = (WINDOW_H_TYPING as f64 * ui_scale) as i32;
+    eprintln!("[pill] DPI scale: {ui_scale}, window: {window_w}x{window_h}");
 
     let class_name = w!("VoquillPill");
     let hinstance = unsafe { GetModuleHandleW(None).unwrap() };
@@ -54,7 +74,7 @@ pub fn run(receiver: Receiver<InMessage>) {
     };
     unsafe { RegisterClassExW(&wc); }
 
-    let (wx, wy) = initial_position();
+    let (wx, wy) = initial_position(ui_scale);
     let hwnd = unsafe {
         CreateWindowExW(
             WS_EX_LAYERED | WS_EX_TOPMOST | WS_EX_TOOLWINDOW | WS_EX_NOACTIVATE,
@@ -62,7 +82,7 @@ pub fn run(receiver: Receiver<InMessage>) {
             w!("VoquillPill"),
             WS_POPUP,
             wx, wy,
-            WINDOW_W_TYPING, WINDOW_H_TYPING,
+            window_w, window_h,
             None, None, Some(hinstance.into()), None,
         ).unwrap()
     };
@@ -70,10 +90,11 @@ pub fn run(receiver: Receiver<InMessage>) {
     HWND_CELL.with(|c| c.set(hwnd));
     eprintln!("[pill] window created in {:?}", t0.elapsed());
 
-    let gfx = Gfx::new(WINDOW_W_TYPING, WINDOW_H_TYPING).expect("Failed to create D2D context");
+    let gfx = Gfx::new(window_w, window_h).expect("Failed to create D2D context");
     eprintln!("[pill] D2D/DWrite initialized in {:?}", t0.elapsed());
 
     let state = PillState {
+        ui_scale: Cell::new(ui_scale),
         phase: Cell::new(Phase::Idle),
         visibility: Cell::new(Visibility::WhileActive),
         expand_t: Cell::new(0.0),
@@ -198,9 +219,10 @@ unsafe extern "system" fn wndproc(hwnd: HWND, msg: u32, wparam: WPARAM, lparam: 
             let raw_y = ((lparam.0 >> 16) & 0xFFFF) as i16 as f64;
             STATE.with(|s| {
                 if let Some(ref state) = *s.borrow() {
+                    let scale = state.ui_scale.get();
                     let (ox, oy) = state.content_offset();
-                    let x = raw_x - ox;
-                    let y = raw_y - oy;
+                    let x = raw_x / scale - ox;
+                    let y = raw_y / scale - oy;
                     state.mouse_x.set(x);
                     state.mouse_y.set(y);
                     let regions = state.click_regions.borrow();
@@ -236,11 +258,12 @@ unsafe extern "system" fn wndproc(hwnd: HWND, msg: u32, wparam: WPARAM, lparam: 
             LRESULT(0)
         }
         WM_LBUTTONUP => {
-            let x = (lparam.0 & 0xFFFF) as i16 as f64;
-            let y = ((lparam.0 >> 16) & 0xFFFF) as i16 as f64;
+            let raw_x = (lparam.0 & 0xFFFF) as i16 as f64;
+            let raw_y = ((lparam.0 >> 16) & 0xFFFF) as i16 as f64;
             STATE.with(|s| {
                 if let Some(ref state) = *s.borrow() {
-                    input::handle_click(state, x, y);
+                    let scale = state.ui_scale.get();
+                    input::handle_click(state, raw_x / scale, raw_y / scale);
                 }
             });
             LRESULT(0)
@@ -779,29 +802,32 @@ fn check_hover(hwnd: HWND, state: &PillState) {
     let mut win_rect = RECT::default();
     unsafe { let _ = GetWindowRect(hwnd, &mut win_rect); }
 
+    let scale = state.ui_scale.get();
     let (ox, oy) = state.content_offset();
     let dw = state.draw_width.get();
     let dh = state.draw_height.get();
 
-    // Pill position in screen coordinates
+    // Pill position in screen coordinates (DIP → physical)
     let (pill_x, pill_y, pill_w, pill_h) = draw::pill_position(state, dw, dh);
-    let screen_pill_x = win_rect.left as f64 + ox + pill_x;
-    let screen_pill_y = win_rect.top as f64 + oy + pill_y;
+    let screen_pill_x = win_rect.left as f64 + (ox + pill_x) * scale;
+    let screen_pill_y = win_rect.top as f64 + (oy + pill_y) * scale;
+    let screen_pill_w = pill_w * scale;
+    let screen_pill_h = pill_h * scale;
 
-    let pad = if state.hovered.get() { 24.0 } else { 8.0 };
+    let pad = (if state.hovered.get() { 24.0 } else { 8.0 }) * scale;
     let cx = cursor.x as f64;
     let cy = cursor.y as f64;
 
     let in_pill = cx >= screen_pill_x - pad
-        && cx <= screen_pill_x + pill_w + pad
+        && cx <= screen_pill_x + screen_pill_w + pad
         && cy >= screen_pill_y - pad
-        && cy <= screen_pill_y + pill_h + pad;
+        && cy <= screen_pill_y + screen_pill_h + pad;
 
     let in_panel = if state.assistant_active.get() {
-        let panel_x = win_rect.left as f64 + ox;
-        let panel_y = win_rect.top as f64 + oy;
-        cx >= panel_x && cx <= panel_x + dw
-            && cy >= panel_y && cy <= panel_y + dh
+        let panel_x = win_rect.left as f64 + ox * scale;
+        let panel_y = win_rect.top as f64 + oy * scale;
+        cx >= panel_x && cx <= panel_x + dw * scale
+            && cy >= panel_y && cy <= panel_y + dh * scale
     } else {
         false
     };
@@ -844,7 +870,7 @@ fn update_layered(hwnd: HWND, gfx: &Gfx) {
     }
 }
 
-fn initial_position() -> (i32, i32) {
+fn initial_position(ui_scale: f64) -> (i32, i32) {
     unsafe {
         let mut cursor = POINT::default();
         let _ = GetCursorPos(&mut cursor);
@@ -857,8 +883,11 @@ fn initial_position() -> (i32, i32) {
         let wa = info.rcWork;
         let wa_w = wa.right - wa.left;
         let wa_h = wa.bottom - wa.top;
-        let x = wa.left + (wa_w - WINDOW_W_TYPING) / 2;
-        let y = wa.top + wa_h - WINDOW_H_TYPING - MARGIN_BOTTOM;
+        let win_w = (WINDOW_W_TYPING as f64 * ui_scale) as i32;
+        let win_h = (WINDOW_H_TYPING as f64 * ui_scale) as i32;
+        let margin = (MARGIN_BOTTOM as f64 * ui_scale) as i32;
+        let x = wa.left + (wa_w - win_w) / 2;
+        let y = wa.top + wa_h - win_h - margin;
         (x, y)
     }
 }
@@ -868,6 +897,12 @@ fn reposition_to_cursor_monitor(hwnd: HWND) {
         let mut cursor = POINT::default();
         let _ = GetCursorPos(&mut cursor);
         let monitor = MonitorFromPoint(cursor, MONITOR_DEFAULTTOPRIMARY);
+
+        let mut dpi_x: u32 = 96;
+        let mut dpi_y: u32 = 96;
+        let _ = GetDpiForMonitor(monitor, MDT_EFFECTIVE_DPI, &mut dpi_x, &mut dpi_y);
+        let new_scale = (dpi_x as f64 / 96.0).max(1.0);
+
         let mut info = MONITORINFO {
             cbSize: std::mem::size_of::<MONITORINFO>() as u32,
             ..Default::default()
@@ -876,16 +911,49 @@ fn reposition_to_cursor_monitor(hwnd: HWND) {
         let wa = info.rcWork;
         let wa_w = wa.right - wa.left;
         let wa_h = wa.bottom - wa.top;
-        let x = wa.left + (wa_w - WINDOW_W_TYPING) / 2;
-        let y = wa.top + wa_h - WINDOW_H_TYPING - MARGIN_BOTTOM;
+
+        let win_w = (WINDOW_W_TYPING as f64 * new_scale) as i32;
+        let win_h = (WINDOW_H_TYPING as f64 * new_scale) as i32;
+        let margin = (MARGIN_BOTTOM as f64 * new_scale) as i32;
+        let x = wa.left + (wa_w - win_w) / 2;
+        let y = wa.top + wa_h - win_h - margin;
 
         let mut current = RECT::default();
         let _ = GetWindowRect(hwnd, &mut current);
-        if current.left != x || current.top != y {
-            let _ = SetWindowPos(
-                hwnd, None, x, y, 0, 0,
-                SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE,
-            );
+        let cur_w = current.right - current.left;
+        let cur_h = current.bottom - current.top;
+
+        let scale_changed = STATE.with(|s| {
+            if let Some(ref state) = *s.borrow() {
+                let old = state.ui_scale.get();
+                (new_scale - old).abs() > 0.01
+            } else {
+                false
+            }
+        });
+
+        if scale_changed || current.left != x || current.top != y || cur_w != win_w || cur_h != win_h {
+            // Update window position and size
+            let flags = if scale_changed {
+                SWP_NOZORDER | SWP_NOACTIVATE
+            } else {
+                SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE
+            };
+            let _ = SetWindowPos(hwnd, None, x, y, win_w, win_h, flags);
+
+            if scale_changed {
+                STATE.with(|s| {
+                    if let Some(ref state) = *s.borrow() {
+                        state.ui_scale.set(new_scale);
+                        state.dirty.set(true);
+                    }
+                });
+                GFX.with(|g| {
+                    if let Some(ref mut gfx) = *g.borrow_mut() {
+                        gfx.resize(win_w, win_h);
+                    }
+                });
+            }
         }
     }
 }
@@ -1109,6 +1177,8 @@ fn update_edit_overlay(main_hwnd: HWND, state: &PillState) {
         return;
     }
 
+    let scale = state.ui_scale.get();
+
     // Calculate input field position in screen coordinates
     let (ox, oy) = state.content_offset();
     let ww = state.draw_width.get();
@@ -1127,9 +1197,10 @@ fn update_edit_overlay(main_hwnd: HWND, state: &PillState) {
     let mut win_rect = RECT::default();
     unsafe { let _ = GetWindowRect(main_hwnd, &mut win_rect); }
 
-    let screen_x = win_rect.left as f64 + ox + input_x;
-    let screen_y = win_rect.top as f64 + oy + input_y + 1.0;
-    let h = PANEL_INPUT_HEIGHT - 1.0;
+    let screen_x = win_rect.left as f64 + (ox + input_x) * scale;
+    let screen_y = win_rect.top as f64 + (oy + input_y + 1.0) * scale;
+    let h = ((PANEL_INPUT_HEIGHT - 1.0) * scale) as i32;
+    let w = (input_w * scale) as i32;
 
     unsafe {
         // Color key makes the background transparent; alpha matches text to panel opacity
@@ -1142,13 +1213,13 @@ fn update_edit_overlay(main_hwnd: HWND, state: &PillState) {
         let _ = SetWindowPos(
             container, None,
             screen_x as i32, screen_y as i32,
-            input_w as i32, h as i32,
+            w, h,
             SWP_NOZORDER | SWP_NOACTIVATE | SWP_SHOWWINDOW,
         );
         let _ = SetWindowPos(
             edit, None,
             0, 0,
-            input_w as i32, h as i32,
+            w, h,
             SWP_NOZORDER | SWP_NOACTIVATE | SWP_NOMOVE,
         );
     }

--- a/packages/rust_windows_pill/src/pill.rs
+++ b/packages/rust_windows_pill/src/pill.rs
@@ -53,6 +53,7 @@ fn get_dpi_scale() -> f64 {
 pub fn run(receiver: Receiver<InMessage>) {
     let t0 = Instant::now();
     unsafe {
+        let _ = windows::Win32::System::Com::CoInitializeEx(None, windows::Win32::System::Com::COINIT_APARTMENTTHREADED);
         let _ = windows::Win32::UI::HiDpi::SetProcessDpiAwarenessContext(
             windows::Win32::UI::HiDpi::DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2,
         );
@@ -193,6 +194,7 @@ pub fn run(receiver: Receiver<InMessage>) {
             while PeekMessageW(&mut msg, None, 0, 0, PM_REMOVE).as_bool() {
                 if msg.message == WM_QUIT {
                     windows::Win32::Media::timeEndPeriod(1);
+                    windows::Win32::System::Com::CoUninitialize();
                     return;
                 }
                 if handle_edit_message(&msg) { continue; }
@@ -211,6 +213,7 @@ pub fn run(receiver: Receiver<InMessage>) {
             }
         }
         windows::Win32::Media::timeEndPeriod(1);
+        windows::Win32::System::Com::CoUninitialize();
     }
 }
 

--- a/packages/rust_windows_pill/src/state.rs
+++ b/packages/rust_windows_pill/src/state.rs
@@ -104,6 +104,7 @@ pub(crate) struct FlameTongue {
 }
 
 pub(crate) struct PillState {
+    pub(crate) ui_scale: Cell<f64>,
     pub(crate) phase: Cell<Phase>,
     pub(crate) visibility: Cell<Visibility>,
     pub(crate) expand_t: Cell<f64>,


### PR DESCRIPTION
## Summary

The native Windows dictation pill overlay had two issues when running on Windows 10/11:

1. **Didn't respect display scaling** — on high-DPI displays (125%, 150%, 200%, etc.), the pill rendered at a fraction of its intended visual size because all constants were designed for 96 DPI but the process runs with `PER_MONITOR_AWARE_V2` (physical pixel coordinates).

2. **Didn't follow virtual desktops** — when switching desktops via `Win+Ctrl+Left/Right`, the pill stayed behind on the original desktop and was invisible on the new one.

## Changes

### DPI scaling fix (`state.rs`, `pill.rs`, `draw.rs`)

- Computes the monitor's effective DPI at startup via `GetDpiForMonitor(MDT_EFFECTIVE_DPI)`
- Multiplies the layered window and Direct2D bitmap dimensions by `dpi / 96.0` (physical pixels)
- Applies a `gfx.scale(ui_scale, ui_scale)` transform in `draw_all()` so all existing drawing coordinates remain unchanged (DIPs)
- Adjusts mouse hit-testing (`WM_MOUSEMOVE`, `WM_LBUTTONUP`, `check_hover`) to translate between physical mouse events and DIP coordinate space
- Scales the embedded edit overlay position/dimensions
- Detects DPI changes when the cursor moves between different-DPI monitors and resizes dynamically

### Virtual desktop following (`pill.rs`)

- Initializes `IVirtualDesktopManager` COM interface at startup (requires explicit `CoInitializeEx`)
- On each cursor tick (every ~60ms), checks `IsWindowOnCurrentVirtualDesktop`
- When a desktop-switch is detected, creates a temporary hidden window to retrieve the current desktop GUID, then calls `MoveWindowToDesktop` to bring the pill along
- No overhead on normal operation — temp window only created on actual desktop switch events

### Platform scope

- **Only** `packages/rust_windows_pill/` — no other platforms or packages affected
- macOS already handles Retina scaling automatically via Cocoa's backing scale factor
- Linux uses GDK application pixels directly via the compositor

## Testing

- Display scaling verified at 125% (750x452 physical window, log: `DPI scale: 1.25`)
- Virtual desktop following verified (pill moves with user across desktops)
- Multiple dictation sessions completed successfully
- Cursor hover and click detection on scaled pill
