### PR TITLE
Update DeepSeek models to v4 (deepseek-v4-flash, deepseek-v4-pro)

### DIFF
--- a/apps/desktop/src/repos/generate-text.repo.ts
+++ b/apps/desktop/src/repos/generate-text.repo.ts
@@ -347,7 +347,7 @@ export class DeepseekGenerateTextRepo extends BaseGenerateTextRepo {
   constructor(apiKey: string, model: string | null) {
     super();
     this.apiKey = apiKey;
-    this.model = (model as DeepseekModel) ?? "deepseek-chat";
+    this.model = (model as DeepseekModel) ?? "deepseek-v4-flash";
   }
 
   async generateText(input: GenerateTextInput): Promise<GenerateTextOutput> {

--- a/mobile/android/app/src/main/kotlin/com/voquill/mobile/repos/GenerateTextRepo.kt
+++ b/mobile/android/app/src/main/kotlin/com/voquill/mobile/repos/GenerateTextRepo.kt
@@ -75,7 +75,7 @@ class ByokGenerateTextRepo(
             }
             "deepseek" -> {
                 apiUrl = "https://api.deepseek.com/chat/completions"
-                model = modelOverride ?: "deepseek-chat"
+                model = modelOverride ?: "deepseek-v4-flash"
             }
             "openRouter" -> {
                 apiUrl = "https://openrouter.ai/api/v1/chat/completions"

--- a/mobile/ios/keyboard/Repos/ByokGenerateTextRepo.swift
+++ b/mobile/ios/keyboard/Repos/ByokGenerateTextRepo.swift
@@ -15,7 +15,7 @@ class ByokGenerateTextRepo: BaseGenerateTextRepo {
             self.model = modelOverride ?? "llama-3.3-70b-versatile"
         case "deepseek":
             self.apiUrl = "https://api.deepseek.com/chat/completions"
-            self.model = modelOverride ?? "deepseek-chat"
+            self.model = modelOverride ?? "deepseek-v4-flash"
         case "openRouter":
             self.apiUrl = "https://openrouter.ai/api/v1/chat/completions"
             self.model = modelOverride ?? "openai/gpt-4o-mini"

--- a/mobile/lib/widgets/settings/add_api_key_dialog.dart
+++ b/mobile/lib/widgets/settings/add_api_key_dialog.dart
@@ -288,7 +288,7 @@ class _AddApiKeyDialogState extends State<AddApiKeyDialog> {
       case ApiKeyProvider.groq:
         return isTranscription ? 'e.g. whisper-large-v3' : 'e.g. llama-3.3-70b-versatile';
       case ApiKeyProvider.deepseek:
-        return 'e.g. deepseek-chat';
+        return 'e.g. deepseek-v4-flash';
       case ApiKeyProvider.openRouter:
         return 'e.g. openai/gpt-4o-mini';
       case ApiKeyProvider.openaiCompatible:

--- a/packages/voice-ai/src/deepseek.utils.ts
+++ b/packages/voice-ai/src/deepseek.utils.ts
@@ -4,10 +4,17 @@ import {
   ChatCompletionMessageParam,
 } from "openai/resources/chat/completions";
 import { retry, countWords } from "@voquill/utilities";
-import type { JsonResponse, LlmChatInput, LlmStreamEvent } from "@voquill/types";
+import type {
+  JsonResponse,
+  LlmChatInput,
+  LlmStreamEvent,
+} from "@voquill/types";
 import { openaiCompatibleStreamChat } from "./openai.utils";
 
-export const DEEPSEEK_MODELS = ["deepseek-chat", "deepseek-reasoner"] as const;
+export const DEEPSEEK_MODELS = [
+  "deepseek-v4-flash",
+  "deepseek-v4-pro",
+] as const;
 export type DeepseekModel = (typeof DEEPSEEK_MODELS)[number];
 
 const DEEPSEEK_BASE_URL = "https://api.deepseek.com";
@@ -44,7 +51,7 @@ const createClient = (apiKey: string) => {
 
 export type DeepseekGenerateTextArgs = {
   apiKey: string;
-  model?: DeepseekModel;
+  model?: string;
   system?: string;
   prompt: string;
   jsonResponse?: JsonResponse;
@@ -57,7 +64,7 @@ export type DeepseekGenerateResponseOutput = {
 
 export const deepseekGenerateTextResponse = async ({
   apiKey,
-  model = "deepseek-chat",
+  model = "deepseek-v4-flash",
   system,
   prompt,
   jsonResponse,
@@ -130,7 +137,7 @@ export const deepseekTestIntegration = async ({
         ],
       },
     ],
-    model: "deepseek-chat",
+    model: "deepseek-v4-flash",
     temperature: 0,
     max_tokens: 32,
     top_p: 1,


### PR DESCRIPTION
## Update DeepSeek models to v4

Update deprecated DeepSeek models to v4 according to [official documentation](https://api-docs.deepseek.com/). The old models `deepseek-chat` and `deepseek-reasoner` will be deprecated on 2026/07/24.

### Changes

- **Core update**: packages/voice-ai/src/deepseek.utils.ts
  - `DEEPSEEK_MODELS`: `["deepseek-chat", "deepseek-reasoner"]` → `["deepseek-v4-flash", "deepseek-v4-pro"]`
  - Default model: `deepseek-chat` → `deepseek-v4-flash`

- **Desktop**: apps/desktop/src/repos/generate-text.repo.ts
  - Updated default model in DeepseekGenerateTextRepo

- **Mobile platforms**:
  - Android: mobile/android/app/src/main/kotlin/com/voquill/mobile/repos/GenerateTextRepo.kt
  - Flutter: mobile/lib/widgets/settings/add_api_key_dialog.dart
  - iOS: mobile/ios/keyboard/Repos/ByokGenerateTextRepo.swift

### Testing

1. **Manual verification**:
   - Ran dev emulator and configured DeepSeek API key
   - Verify new model names appear in the model list
   - Test post-processing functionality

2. **Code review**: Confirm all references have been updated

### Compatibility Note

Per official documentation, for compatibility:
- `deepseek-chat` maps to `deepseek-v4-flash` (non-thinking mode)
- `deepseek-reasoner` maps to `deepseek-v4-pro` (thinking mode)
