### PR TITLE
Fix Deepgram auto-detect transcription

### DIFF
--- a/apps/desktop/src-tauri/src/app.rs
+++ b/apps/desktop/src-tauri/src/app.rs
@@ -80,29 +80,24 @@ pub fn build() -> tauri::Builder<tauri::Wry> {
         )
         .on_window_event(|window, event| {
             match event {
-                WindowEvent::CloseRequested { api, .. } => {
-                    if window.label() == "main" {
-                        api.prevent_close();
-                        let _ = window
-                            .app_handle()
-                            .save_window_state(StateFlags::SIZE | StateFlags::POSITION);
-                        let _ = window.hide();
-                        // On Windows, force the WebView to stay active after hiding the window
-                        // so that background JS (global hotkey detection via keys_held events)
-                        // continues running while the app is minimized to the system tray.
-                        #[cfg(target_os = "windows")]
-                        {
-                            crate::platform::window::keep_webview_active(
-                                window.app_handle(),
-                                "main",
-                            );
-                            crate::platform::window::set_webview_keepalive(true);
-                        }
-                        #[cfg(target_os = "macos")]
-                        {
-                            if let Err(err) = crate::platform::macos::dock::hide_dock_icon() {
-                                log::error!("Failed to hide dock icon: {err}");
-                            }
+                WindowEvent::CloseRequested { api, .. } if window.label() == "main" => {
+                    api.prevent_close();
+                    let _ = window
+                        .app_handle()
+                        .save_window_state(StateFlags::SIZE | StateFlags::POSITION);
+                    let _ = window.hide();
+                    // On Windows, force the WebView to stay active after hiding the window
+                    // so that background JS (global hotkey detection via keys_held events)
+                    // continues running while the app is minimized to the system tray.
+                    #[cfg(target_os = "windows")]
+                    {
+                        crate::platform::window::keep_webview_active(window.app_handle(), "main");
+                        crate::platform::window::set_webview_keepalive(true);
+                    }
+                    #[cfg(target_os = "macos")]
+                    {
+                        if let Err(err) = crate::platform::macos::dock::hide_dock_icon() {
+                            log::error!("Failed to hide dock icon: {err}");
                         }
                     }
                 }

--- a/apps/desktop/src/repos/index.ts
+++ b/apps/desktop/src/repos/index.ts
@@ -99,6 +99,7 @@ import {
   AldeaTranscribeAudioRepo,
   AzureTranscribeAudioRepo,
   BaseTranscribeAudioRepo,
+  DeepgramTranscribeAudioRepo,
   ElevenLabsTranscribeAudioRepo,
   EnterpriseTranscribeAudioRepo,
   GeminiTranscribeAudioRepo,
@@ -448,6 +449,11 @@ export const getTranscribeAudioRepo = (): TranscribeAudioRepoOutput => {
       );
     } else if (prefs.provider === "elevenlabs") {
       repo = new ElevenLabsTranscribeAudioRepo(prefs.apiKeyValue);
+    } else if (prefs.provider === "deepgram") {
+      repo = new DeepgramTranscribeAudioRepo(
+        prefs.apiKeyValue,
+        prefs.transcriptionModel,
+      );
     } else if (prefs.provider === "xai") {
       repo = new XaiTranscribeAudioRepo(
         prefs.apiKeyValue,

--- a/apps/desktop/src/repos/model-provider.repo.ts
+++ b/apps/desktop/src/repos/model-provider.repo.ts
@@ -2,6 +2,7 @@ import {
   AZURE_OPENAI_MODELS,
   CEREBRAS_MODELS,
   CLAUDE_MODELS,
+  DEEPGRAM_TRANSCRIPTION_MODELS,
   DEEPSEEK_MODELS,
   GEMINI_GENERATE_TEXT_MODELS,
   GEMINI_TRANSCRIPTION_MODELS,
@@ -501,6 +502,6 @@ export class DeepgramModelProviderRepo extends BaseModelProviderRepo {
   }
 
   async getTranscriptionModels(): Promise<string[]> {
-    return ["nova-3"];
+    return [...DEEPGRAM_TRANSCRIPTION_MODELS];
   }
 }

--- a/apps/desktop/src/repos/transcribe-audio.repo.test.ts
+++ b/apps/desktop/src/repos/transcribe-audio.repo.test.ts
@@ -1,6 +1,10 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { INITIAL_APP_STATE } from "../state/app.state";
+import { setAppState } from "../store";
+import { getTranscribeAudioRepo } from ".";
 import {
   BaseTranscribeAudioRepo,
+  DeepgramTranscribeAudioRepo,
   TranscribeAudioOutput,
   TranscribeSegmentInput,
 } from "./transcribe-audio.repo";
@@ -74,6 +78,19 @@ class MockTranscribeAudioRepo extends BaseTranscribeAudioRepo {
 // Helper to create samples of a specific duration
 const createSamples = (durationSec: number, sampleRate: number): Float32Array =>
   new Float32Array(Math.floor(durationSec * sampleRate));
+
+const resetStore = () => {
+  setAppState(structuredClone(INITIAL_APP_STATE), true);
+};
+
+beforeEach(() => {
+  resetStore();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  resetStore();
+});
 
 describe("BaseTranscribeAudioRepo", () => {
   describe("short audio (no splitting)", () => {
@@ -276,5 +293,62 @@ describe("BaseTranscribeAudioRepo", () => {
         "In the beginning there was silence and then came the sound of voices speaking softly in the distance growing louder with each passing moment",
       );
     });
+  });
+});
+
+describe("DeepgramTranscribeAudioRepo", () => {
+  it("requests Deepgram language detection for automatic language", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          results: {
+            channels: [
+              {
+                alternatives: [{ transcript: "bonjour tout le monde" }],
+              },
+            ],
+          },
+        }),
+        { status: 200 },
+      ),
+    );
+    const repo = new DeepgramTranscribeAudioRepo("dg-key", null);
+
+    const result = await repo.transcribeAudio({
+      samples: createSamples(1, 16000),
+      sampleRate: 16000,
+      language: "auto",
+    });
+
+    const [url, init] = fetchMock.mock.calls[0] ?? [];
+    const requestUrl = new URL(String(url));
+
+    expect(result.text).toBe("bonjour tout le monde");
+    expect(requestUrl.searchParams.get("detect_language")).toBe("true");
+    expect(requestUrl.searchParams.has("language")).toBe(false);
+    expect(init?.headers).toMatchObject({
+      Authorization: "Token dg-key",
+      "Content-Type": "audio/wav",
+    });
+  });
+
+  it("is selected for Deepgram API transcription preferences", () => {
+    const state = structuredClone(INITIAL_APP_STATE);
+    state.settings.aiTranscription.mode = "api";
+    state.settings.aiTranscription.selectedApiKeyId = "deepgram-key";
+    state.apiKeyById["deepgram-key"] = {
+      id: "deepgram-key",
+      name: "Deepgram",
+      provider: "deepgram",
+      createdAt: "2026-06-03T00:00:00.000Z",
+      keyFull: "dg-key",
+      transcriptionModel: "nova-3",
+    };
+    setAppState(state, true);
+
+    const { repo, apiKeyId } = getTranscribeAudioRepo();
+
+    expect(repo).toBeInstanceOf(DeepgramTranscribeAudioRepo);
+    expect(apiKeyId).toBe("deepgram-key");
   });
 });

--- a/apps/desktop/src/repos/transcribe-audio.repo.ts
+++ b/apps/desktop/src/repos/transcribe-audio.repo.ts
@@ -4,6 +4,7 @@ import { batchAsync } from "@voquill/utilities";
 import {
   aldeaTranscribeAudio,
   azureTranscribeAudio,
+  deepgramTranscribeAudio,
   elevenlabsTranscribeAudio,
   geminiTranscribeAudio,
   GeminiTranscriptionModel,
@@ -444,6 +445,52 @@ export class ElevenLabsTranscribeAudioRepo extends BaseTranscribeAudioRepo {
       metadata: {
         inferenceDevice: "API • ElevenLabs",
         modelSize: null,
+        transcriptionMode: "api",
+      },
+    };
+  }
+}
+
+export class DeepgramTranscribeAudioRepo extends BaseTranscribeAudioRepo {
+  private apiKey: string;
+  private model: string;
+
+  constructor(apiKey: string, model: string | null) {
+    super();
+    this.apiKey = apiKey;
+    this.model = model ?? "nova-3";
+  }
+
+  protected getSegmentDurationSec(): number {
+    return 60;
+  }
+
+  protected getOverlapDurationSec(): number {
+    return 5;
+  }
+
+  protected getBatchChunkCount(): number {
+    return 3;
+  }
+
+  protected async transcribeSegment(
+    input: TranscribeSegmentInput,
+  ): Promise<TranscribeAudioOutput> {
+    const wavBuffer = buildWaveFile(input.samples, input.sampleRate);
+
+    const { text: transcript } = await deepgramTranscribeAudio({
+      apiKey: this.apiKey,
+      model: this.model,
+      blob: wavBuffer,
+      ext: "wav",
+      language: input.language,
+    });
+
+    return {
+      text: transcript,
+      metadata: {
+        inferenceDevice: "API • Deepgram",
+        modelSize: this.model,
         transcriptionMode: "api",
       },
     };

--- a/apps/desktop/src/utils/deepgram.utils.test.ts
+++ b/apps/desktop/src/utils/deepgram.utils.test.ts
@@ -26,6 +26,17 @@ describe("buildDeepgramWebSocketUrl", () => {
     expect(url.searchParams.get("language")).toBe("zh-TW");
   });
 
+  it("uses Deepgram multilingual streaming for automatic language detection", () => {
+    const url = new URL(
+      buildDeepgramWebSocketUrl({
+        sampleRate: 16000,
+        language: "auto",
+      }),
+    );
+
+    expect(url.searchParams.get("language")).toBe("multi");
+  });
+
   it("omits the language parameter when no language is provided", () => {
     const url = new URL(
       buildDeepgramWebSocketUrl({

--- a/apps/desktop/src/utils/deepgram.utils.ts
+++ b/apps/desktop/src/utils/deepgram.utils.ts
@@ -12,7 +12,9 @@ export const buildDeepgramWebSocketUrl = (args: {
     endpointing: "300",
   });
 
-  if (args.language && args.language !== "auto") {
+  if (args.language === "auto") {
+    params.set("language", "multi");
+  } else if (args.language) {
     params.set("language", args.language);
   }
 

--- a/packages/voice-ai/src/deepgram.utils.ts
+++ b/packages/voice-ai/src/deepgram.utils.ts
@@ -1,6 +1,14 @@
+import { countWords, retry } from "@voquill/utilities";
+
 export type DeepgramTestIntegrationArgs = {
   apiKey: string;
 };
+
+export const DEEPGRAM_TRANSCRIPTION_MODELS = ["nova-3"] as const;
+export type DeepgramTranscriptionModel =
+  (typeof DEEPGRAM_TRANSCRIPTION_MODELS)[number];
+
+const DEEPGRAM_LISTEN_URL = "https://api.deepgram.com/v1/listen";
 
 export const deepgramTestIntegration = ({
   apiKey,
@@ -31,5 +39,85 @@ export const deepgramTestIntegration = ({
         resolve(false);
       }
     };
+  });
+};
+
+export type DeepgramTranscriptionArgs = {
+  apiKey: string;
+  model?: string;
+  blob: ArrayBuffer | Buffer;
+  ext: string;
+  language?: string;
+};
+
+export type DeepgramTranscribeAudioOutput = {
+  text: string;
+  wordsUsed: number;
+};
+
+export const deepgramTranscribeAudio = async ({
+  apiKey,
+  model = "nova-3",
+  blob,
+  ext,
+  language,
+}: DeepgramTranscriptionArgs): Promise<DeepgramTranscribeAudioOutput> => {
+  return retry({
+    retries: 3,
+    fn: async () => {
+      const params = new URLSearchParams({
+        model,
+        punctuate: "true",
+        smart_format: "true",
+      });
+
+      if (language && language !== "auto") {
+        params.set("language", language);
+      } else {
+        params.set("detect_language", "true");
+      }
+
+      const response = await fetch(
+        `${DEEPGRAM_LISTEN_URL}?${params.toString()}`,
+        {
+          method: "POST",
+          headers: {
+            Authorization: `Token ${apiKey.trim()}`,
+            "Content-Type": `audio/${ext}`,
+          },
+          body:
+            blob instanceof ArrayBuffer ? blob : (blob.buffer as ArrayBuffer),
+        },
+      );
+
+      if (!response.ok) {
+        const errorText = await response.text().catch(() => "Unknown error");
+        throw new Error(
+          `Deepgram transcription request failed with status ${response.status}: ${errorText}`,
+        );
+      }
+
+      const data = (await response.json()) as {
+        results?: {
+          channels?: Array<{
+            alternatives?: Array<{
+              transcript?: string;
+            }>;
+          }>;
+        };
+      };
+      const transcript =
+        data.results?.channels?.[0]?.alternatives?.[0]?.transcript?.trim() ??
+        "";
+
+      if (!transcript) {
+        throw new Error("Transcription failed: No text in Deepgram response");
+      }
+
+      return {
+        text: transcript,
+        wordsUsed: countWords(transcript),
+      };
+    },
   });
 };


### PR DESCRIPTION
## Summary

**TL;DR: Fixes auto-detect language setting for Deepgram**

- adds Deepgram as an API transcription repo path
- sends `detect_language=true` for batch Deepgram transcription when language is `auto`
- keeps Deepgram streaming auto-detect on multilingual mode
- adds coverage for Deepgram auto-detect requests and repo selection

## Root Cause

The API transcription repo selection did not route Deepgram keys through a Deepgram transcription implementation, and the Deepgram batch request path did not exist to translate Voquill's `auto` language into Deepgram language detection.

