### PR TITLE
Move retranscribe progress to source button

### DIFF
--- a/apps/desktop/src-tauri/src/app.rs
+++ b/apps/desktop/src-tauri/src/app.rs
@@ -80,29 +80,24 @@ pub fn build() -> tauri::Builder<tauri::Wry> {
         )
         .on_window_event(|window, event| {
             match event {
-                WindowEvent::CloseRequested { api, .. } => {
-                    if window.label() == "main" {
-                        api.prevent_close();
-                        let _ = window
-                            .app_handle()
-                            .save_window_state(StateFlags::SIZE | StateFlags::POSITION);
-                        let _ = window.hide();
-                        // On Windows, force the WebView to stay active after hiding the window
-                        // so that background JS (global hotkey detection via keys_held events)
-                        // continues running while the app is minimized to the system tray.
-                        #[cfg(target_os = "windows")]
-                        {
-                            crate::platform::window::keep_webview_active(
-                                window.app_handle(),
-                                "main",
-                            );
-                            crate::platform::window::set_webview_keepalive(true);
-                        }
-                        #[cfg(target_os = "macos")]
-                        {
-                            if let Err(err) = crate::platform::macos::dock::hide_dock_icon() {
-                                log::error!("Failed to hide dock icon: {err}");
-                            }
+                WindowEvent::CloseRequested { api, .. } if window.label() == "main" => {
+                    api.prevent_close();
+                    let _ = window
+                        .app_handle()
+                        .save_window_state(StateFlags::SIZE | StateFlags::POSITION);
+                    let _ = window.hide();
+                    // On Windows, force the WebView to stay active after hiding the window
+                    // so that background JS (global hotkey detection via keys_held events)
+                    // continues running while the app is minimized to the system tray.
+                    #[cfg(target_os = "windows")]
+                    {
+                        crate::platform::window::keep_webview_active(window.app_handle(), "main");
+                        crate::platform::window::set_webview_keepalive(true);
+                    }
+                    #[cfg(target_os = "macos")]
+                    {
+                        if let Err(err) = crate::platform::macos::dock::hide_dock_icon() {
+                            log::error!("Failed to hide dock icon: {err}");
                         }
                     }
                 }

--- a/apps/desktop/src/components/transcriptions/RetranscribeDialog.tsx
+++ b/apps/desktop/src/components/transcriptions/RetranscribeDialog.tsx
@@ -33,6 +33,8 @@ const languageOptions = ORDERED_DICTATION_LANGUAGES.map((code) => ({
   label: DICTATION_LANGUAGES[code],
 }));
 
+const SUCCESS_VISIBLE_DELAY_MS = 900;
+
 export const RetranscribeDialog = () => {
   const intl = useIntl();
 
@@ -63,23 +65,32 @@ export const RetranscribeDialog = () => {
     }
   }, [open, defaultLanguage, tones]);
 
+  const handleClose = useCallback(() => {
+    closeRetranscribeDialog();
+  }, []);
+
   const handleSubmit = useCallback(async () => {
     if (!transcriptionId) return;
 
     closeRetranscribeDialog();
-
     produceAppState((draft) => {
       if (!draft.transcriptions.retranscribingIds.includes(transcriptionId)) {
         draft.transcriptions.retranscribingIds.push(transcriptionId);
       }
+      draft.transcriptions.retranscriptionSuccessIds =
+        draft.transcriptions.retranscriptionSuccessIds.filter(
+          (id) => id !== transcriptionId,
+        );
     });
 
+    let didSucceed = false;
     try {
       await retranscribeTranscription({
         transcriptionId,
         toneId: selectedToneId,
         languageCode: selectedLanguage,
       });
+      didSucceed = true;
     } catch (error) {
       console.error("Failed to retranscribe audio", error);
       const fallbackMessage = intl.formatMessage({
@@ -93,17 +104,30 @@ export const RetranscribeDialog = () => {
           draft.transcriptions.retranscribingIds.filter(
             (id) => id !== transcriptionId,
           );
+        if (
+          didSucceed &&
+          !draft.transcriptions.retranscriptionSuccessIds.includes(
+            transcriptionId,
+          )
+        ) {
+          draft.transcriptions.retranscriptionSuccessIds.push(transcriptionId);
+        }
       });
+      if (didSucceed) {
+        window.setTimeout(() => {
+          produceAppState((draft) => {
+            draft.transcriptions.retranscriptionSuccessIds =
+              draft.transcriptions.retranscriptionSuccessIds.filter(
+                (id) => id !== transcriptionId,
+              );
+          });
+        }, SUCCESS_VISIBLE_DELAY_MS);
+      }
     }
   }, [transcriptionId, selectedToneId, selectedLanguage, intl]);
 
   return (
-    <Dialog
-      open={open}
-      onClose={closeRetranscribeDialog}
-      maxWidth="xs"
-      fullWidth
-    >
+    <Dialog open={open} onClose={handleClose} maxWidth="xs" fullWidth>
       <DialogTitle>
         <FormattedMessage defaultMessage="Retranscribe" />
       </DialogTitle>
@@ -150,7 +174,7 @@ export const RetranscribeDialog = () => {
         </Stack>
       </DialogContent>
       <DialogActions>
-        <Button onClick={closeRetranscribeDialog}>
+        <Button onClick={handleClose}>
           <FormattedMessage defaultMessage="Cancel" />
         </Button>
         <Button variant="contained" onClick={handleSubmit}>

--- a/apps/desktop/src/components/transcriptions/TranscriptRow.tsx
+++ b/apps/desktop/src/components/transcriptions/TranscriptRow.tsx
@@ -1,4 +1,5 @@
 import ContentCopyRoundedIcon from "@mui/icons-material/ContentCopyRounded";
+import CheckCircleRoundedIcon from "@mui/icons-material/CheckCircleRounded";
 import DeleteOutlineRoundedIcon from "@mui/icons-material/DeleteOutlineRounded";
 import FileDownloadOutlinedIcon from "@mui/icons-material/FileDownloadOutlined";
 import FlagOutlinedIcon from "@mui/icons-material/FlagOutlined";
@@ -7,6 +8,7 @@ import ReplayRoundedIcon from "@mui/icons-material/ReplayRounded";
 import SendRoundedIcon from "@mui/icons-material/SendRounded";
 import {
   Chip,
+  CircularProgress,
   Divider,
   IconButton,
   Stack,
@@ -52,11 +54,19 @@ export const TranscriptionRow = ({ id }: TranscriptionRowProps) => {
   const isRetranscribing = useAppStore((state) =>
     state.transcriptions.retranscribingIds.includes(id),
   );
+  const didRetranscribe = useAppStore((state) =>
+    state.transcriptions.retranscriptionSuccessIds.includes(id),
+  );
 
   const audioSnapshot = transcription?.audio;
   const activeRemoteTarget = useAppStore(getActiveRemoteTarget);
   const isRemoteTranscript = transcription?.remoteStatus === "received";
   const isSentToRemote = transcription?.remoteStatus === "sent";
+  const retranscribeTooltip = isRetranscribing
+    ? intl.formatMessage({ defaultMessage: "Retranscribing audio clip" })
+    : didRetranscribe
+      ? intl.formatMessage({ defaultMessage: "Retranscribed audio clip" })
+      : intl.formatMessage({ defaultMessage: "Retranscribe audio clip" });
 
   const handleDetailsOpen = useCallback(() => {
     openTranscriptionDetailsDialog(id);
@@ -234,12 +244,7 @@ export const TranscriptionRow = ({ id }: TranscriptionRowProps) => {
           disabled={isRetranscribing}
           actions={
             <>
-              <Tooltip
-                title={intl.formatMessage({
-                  defaultMessage: "Retranscribe audio clip",
-                })}
-                placement="top"
-              >
+              <Tooltip title={retranscribeTooltip} placement="top">
                 <IconButton
                   aria-label={intl.formatMessage({
                     defaultMessage: "Retranscribe audio",
@@ -249,7 +254,13 @@ export const TranscriptionRow = ({ id }: TranscriptionRowProps) => {
                   disabled={isRetranscribing}
                   sx={{ p: 0.5 }}
                 >
-                  <ReplayRoundedIcon fontSize="small" />
+                  {isRetranscribing ? (
+                    <CircularProgress size={18} color="inherit" />
+                  ) : didRetranscribe ? (
+                    <CheckCircleRoundedIcon color="success" fontSize="small" />
+                  ) : (
+                    <ReplayRoundedIcon fontSize="small" />
+                  )}
                 </IconButton>
               </Tooltip>
               <Tooltip

--- a/apps/desktop/src/components/transcriptions/TranscriptionDetailsDialog.tsx
+++ b/apps/desktop/src/components/transcriptions/TranscriptionDetailsDialog.tsx
@@ -1,7 +1,9 @@
+import CheckCircleRoundedIcon from "@mui/icons-material/CheckCircleRounded";
 import ReplayRoundedIcon from "@mui/icons-material/ReplayRounded";
 import {
   Box,
   Button,
+  CircularProgress,
   Dialog,
   DialogActions,
   DialogContent,
@@ -70,6 +72,13 @@ export const TranscriptionDetailsDialog = () => {
   const isRetranscribing = useAppStore((state) =>
     transcription?.id
       ? state.transcriptions.retranscribingIds.includes(transcription.id)
+      : false,
+  );
+  const didRetranscribe = useAppStore((state) =>
+    transcription?.id
+      ? state.transcriptions.retranscriptionSuccessIds.includes(
+          transcription.id,
+        )
       : false,
   );
 
@@ -415,7 +424,15 @@ export const TranscriptionDetailsDialog = () => {
       </DialogContent>
       <DialogActions>
         <Button
-          startIcon={<ReplayRoundedIcon />}
+          startIcon={
+            isRetranscribing ? (
+              <CircularProgress size={16} color="inherit" />
+            ) : didRetranscribe ? (
+              <CheckCircleRoundedIcon color="success" />
+            ) : (
+              <ReplayRoundedIcon />
+            )
+          }
           onClick={() => {
             if (transcription?.id) {
               closeTranscriptionDetailsDialog();

--- a/apps/desktop/src/state/transcriptions.state.ts
+++ b/apps/desktop/src/state/transcriptions.state.ts
@@ -9,6 +9,7 @@ export type TranscriptionsState = {
   retranscribeDialogOpen: boolean;
   retranscribeDialogTranscriptionId: Nullable<string>;
   retranscribingIds: string[];
+  retranscriptionSuccessIds: string[];
   flagDialogOpen: boolean;
   flagDialogTranscriptionId: Nullable<string>;
 };
@@ -21,6 +22,7 @@ export const INITIAL_TRANSCRIPTIONS_STATE: TranscriptionsState = {
   retranscribeDialogOpen: false,
   retranscribeDialogTranscriptionId: null,
   retranscribingIds: [],
+  retranscriptionSuccessIds: [],
   flagDialogOpen: false,
   flagDialogTranscriptionId: null,
 };


### PR DESCRIPTION
## Summary

https://github.com/user-attachments/assets/8027de87-739f-4fd2-b01d-e7053045015e



## Root Cause

Retranscription progress was owned by the modal submit button, so the modal stayed in a loading/success state even though the user's actual action target is the retranscribe control on the transcription itself.

## Validation

- `pnpm --filter desktop build`
- `pnpm --filter desktop lint`
