### PR TITLE
Show auto-detect in retranscribe language menu

### DIFF
--- a/apps/desktop/src-tauri/src/app.rs
+++ b/apps/desktop/src-tauri/src/app.rs
@@ -80,29 +80,24 @@ pub fn build() -> tauri::Builder<tauri::Wry> {
         )
         .on_window_event(|window, event| {
             match event {
-                WindowEvent::CloseRequested { api, .. } => {
-                    if window.label() == "main" {
-                        api.prevent_close();
-                        let _ = window
-                            .app_handle()
-                            .save_window_state(StateFlags::SIZE | StateFlags::POSITION);
-                        let _ = window.hide();
-                        // On Windows, force the WebView to stay active after hiding the window
-                        // so that background JS (global hotkey detection via keys_held events)
-                        // continues running while the app is minimized to the system tray.
-                        #[cfg(target_os = "windows")]
-                        {
-                            crate::platform::window::keep_webview_active(
-                                window.app_handle(),
-                                "main",
-                            );
-                            crate::platform::window::set_webview_keepalive(true);
-                        }
-                        #[cfg(target_os = "macos")]
-                        {
-                            if let Err(err) = crate::platform::macos::dock::hide_dock_icon() {
-                                log::error!("Failed to hide dock icon: {err}");
-                            }
+                WindowEvent::CloseRequested { api, .. } if window.label() == "main" => {
+                    api.prevent_close();
+                    let _ = window
+                        .app_handle()
+                        .save_window_state(StateFlags::SIZE | StateFlags::POSITION);
+                    let _ = window.hide();
+                    // On Windows, force the WebView to stay active after hiding the window
+                    // so that background JS (global hotkey detection via keys_held events)
+                    // continues running while the app is minimized to the system tray.
+                    #[cfg(target_os = "windows")]
+                    {
+                        crate::platform::window::keep_webview_active(window.app_handle(), "main");
+                        crate::platform::window::set_webview_keepalive(true);
+                    }
+                    #[cfg(target_os = "macos")]
+                    {
+                        if let Err(err) = crate::platform::macos::dock::hide_dock_icon() {
+                            log::error!("Failed to hide dock icon: {err}");
                         }
                     }
                 }

--- a/apps/desktop/src/components/transcriptions/RetranscribeDialog.tsx
+++ b/apps/desktop/src/components/transcriptions/RetranscribeDialog.tsx
@@ -21,6 +21,7 @@ import {
 } from "../../actions/transcriptions.actions";
 import { produceAppState, useAppStore } from "../../store";
 import {
+  AUTO_LANGUAGE,
   DICTATION_LANGUAGES,
   type DictationLanguageCode,
   ORDERED_DICTATION_LANGUAGES,
@@ -28,7 +29,12 @@ import {
 import { getSortedToneIds } from "../../utils/tone.utils";
 import { getMyDictationLanguage } from "../../utils/user.utils";
 
-const languageOptions = ORDERED_DICTATION_LANGUAGES.map((code) => ({
+const languageOptions = (
+  [
+    AUTO_LANGUAGE,
+    ...ORDERED_DICTATION_LANGUAGES,
+  ] satisfies DictationLanguageCode[]
+).map((code) => ({
   code,
   label: DICTATION_LANGUAGES[code],
 }));


### PR DESCRIPTION
## Summary

https://github.com/user-attachments/assets/fd1dfa25-72af-4967-a4ea-946ac63b6f70



## Root Cause

The retranscribe modal built its language menu from `ORDERED_DICTATION_LANGUAGES`, which excludes the special `auto` option even though `DICTATION_LANGUAGES` supports it. When the selected value was `auto`, MUI had no matching menu item and rendered the field empty.
