### PR TITLE
fix(gtk-pill): position pill correctly on X11 HiDPI displays

### DIFF
--- a/packages/rust_gtk_pill/src/x11.rs
+++ b/packages/rust_gtk_pill/src/x11.rs
@@ -123,8 +123,10 @@ pub(crate) fn setup_x11_window(window: &gtk::Window) {
                     let wa_w = wa.width() as f64 * scale;
                     let wa_h = wa.height() as f64 * scale;
                     let (alloc_w, alloc_h) = win_ref.size();
-                    let win_w = alloc_w as f64;
-                    let win_h = alloc_h as f64;
+                    // win_ref.size() returns logical pixels; XMoveWindow and the
+                    // workarea math above are in physical pixels, so scale here too.
+                    let win_w = alloc_w as f64 * scale;
+                    let win_h = alloc_h as f64 * scale;
                     let margin = MARGIN_BOTTOM as f64 * scale;
                     return Some((
                         (wa_x + (wa_w - win_w) / 2.0) as c_int,


### PR DESCRIPTION
## Problem

  On Linux/X11 with display scaling (e.g. a 5K monitor at 200%), the recording
  pill is placed below the bottom edge of the screen, so users never see any
  recording/waveform UI while dictating. The pill process runs fine — the window
  is simply positioned off-screen.

  Observed on Ubuntu (GNOME, X11), 5120x2880 @ 200%: the pill window (1200x724
  physical) was placed at y=2502, putting its bottom edge 346 px past the screen
  bottom (2880).

  ## Root cause

  In `pill_pos_on_monitor` (`packages/rust_gtk_pill/src/x11.rs`), the monitor
  workarea is converted to physical pixels by multiplying with the monitor scale
  factor, but the window size from `win_ref.size()` is in GTK logical pixels and
  is used unscaled. Mixing the two units shifts the window down by
  `win_h * (scale - 1)` physical pixels (and right by a smaller amount), pushing
  it off-screen. On scale-1 displays both units are equal, so the bug never
  shows there.

  ## Fix

  Scale the window size by the monitor scale factor as well, so centering and
  bottom alignment hold for any scale. Verified on the setup above: the pill now
  lands at the expected bottom-center position (x=1960, y=2140) and is fully
  visible while recording.

  ## Related

  - #443 fixes the same class of DPI-scaling bug for the Windows pill; this PR
    is the X11 counterpart, in the gtk-pill sidecar's own positioning code.
  - #447 addresses HiDPI monitor-geometry conversion on the Tauri side
    (`platform/linux/monitor.rs`); it does not touch the gtk-pill X11 path
    fixed here, so the two are complementary.
