### PR TITLE
fix(gtk-pill): fall back to XWayland when the compositor lacks layer-shell

### DIFF
--- a/packages/rust_gtk_pill/src/main.rs
+++ b/packages/rust_gtk_pill/src/main.rs
@@ -8,6 +8,34 @@ mod x11;
 
 fn main() {
     gtk::init().expect("Failed to initialize GTK");
+
+    // Compositors without layer-shell support (notably GNOME/Mutter) fall
+    // into the PlainWayland backend, which renders and positions the pill
+    // incorrectly (maximized dock-hint window, broken loading phase).
+    // XWayland behaves exactly like plain X11, which works well, so re-exec
+    // ourselves with the x11 GDK backend there. Compositors with layer-shell
+    // (KDE, sway, Hyprland, ...) are unaffected.
+    //
+    // The host app exports GDK_BACKEND=wayland to its children, so only our
+    // own "x11" value is treated as the already-re-executed marker (this
+    // also prevents an exec loop).
+    let already_x11 = std::env::var("GDK_BACKEND").map(|v| v == "x11").unwrap_or(false);
+    if !already_x11 && !gtk_layer_shell::is_supported() {
+        use gtk::prelude::*;
+        let is_x11_display = gtk::gdk::Display::default()
+            .map(|d| d.type_().name() == "GdkX11Display")
+            .unwrap_or(false);
+        if !is_x11_display {
+            if let Ok(exe) = std::env::current_exe() {
+                use std::os::unix::process::CommandExt;
+                let err = std::process::Command::new(exe)
+                    .env("GDK_BACKEND", "x11")
+                    .exec();
+                eprintln!("re-exec with GDK_BACKEND=x11 failed ({err}), staying on wayland");
+            }
+        }
+    }
+
     let (sender, receiver) = std::sync::mpsc::channel();
     ipc::start_stdin_reader(sender);
     pill::run(receiver);


### PR DESCRIPTION
 ## What changed?

  On GNOME Wayland, Mutter has no layer-shell support, so the pill falls into
  the `PlainWayland` backend (maximized dock-hint window as a positioning
  workaround). In practice this renders incorrectly: the recording phase
  workaround). In practice this renders incorrectly: the recording phase
  shows, but the loading phase never paints, and the pill cannot be
  bottom-anchored reliably.

  XWayland behaves exactly like plain X11, where positioning and rendering
  work well. This PR re-execs the pill process with `GDK_BACKEND=x11` when
  GTK ends up on a Wayland display without layer-shell support.

  Implementation notes:

  - The host app exports `GDK_BACKEND=wayland` to child processes, so only
    our own `x11` value is treated as the already-re-executed marker — this
    also prevents an exec loop.
  - `exec()` preserves the stdin pipe, so the host's IPC keeps working
    across the re-exec.
  - Compositors with layer-shell support (KDE, sway, Hyprland, ...) are
    unaffected and keep using the layer-shell backend.

## How is it tested?

  - [ ] Automated tests
  - [x] Manual verification
  - [x] Code inspection

  Manual verification on Ubuntu 24.04:
  - GNOME Wayland session (Intel iGPU): pill re-execs onto XWayland;
    recording and loading phases both render, bottom-center anchoring works.
  - Plain X11 session (NVIDIA): re-exec does not trigger; behavior unchanged.

