### PR TITLE
add missing dev:linux:gpu script

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -9,6 +9,7 @@
     "dev:mac": "cross-env TAURI_PLATFORM=macos pnpm run dev:tauri",
     "dev:windows": "cross-env TAURI_PLATFORM=windows pnpm run dev:tauri",
     "dev:linux": "cross-env TAURI_PLATFORM=linux pnpm run dev:tauri",
+    "dev:linux:gpu": "cross-env VOQUILL_REQUIRE_GPU_SIDECAR=true TAURI_PLATFORM=linux pnpm run dev:tauri",
     "dev:tauri": "pnpm run prepare:sidecars && node -e \"const c=process.env.TAURI_DEV_CONFIG||'src-tauri/tauri.local.conf.json';require('child_process').execSync('pnpm tauri dev --config '+c,{stdio:'inherit'})\"",
     "dev:vite": "node scripts/run-vite-with-flavor.mjs dev",
     "build": "tsc && node scripts/run-vite-with-flavor.mjs build",


### PR DESCRIPTION
docs/getting-started.md documents `npm run dev:linux:gpu --workspace apps/desktop` for vulkan gpu acceleration, but that script doesn't exist in apps/desktop/package.json.

prepare-sidecars.mjs already supports this via `VOQUILL_REQUIRE_GPU_SIDECAR=true`, which forces the native gpu-vulkan sidecar build instead of silently falling back to cpu. this just wires that existing env var into the documented script name.