### PR TITLE
fix: replacement rules never match multi-word sources

### DIFF
--- a/apps/desktop/src/utils/string.utils.test.ts
+++ b/apps/desktop/src/utils/string.utils.test.ts
@@ -303,6 +303,76 @@ describe("applyReplacements", () => {
     expect(applyReplacements("help world", rules)).toBe("help world");
   });
 
+  it("should replace multi-word sources", () => {
+    const rules = [
+      { sourceValue: "New York", destinationValue: "NYC" },
+      { sourceValue: "Prompt 1", destinationValue: "Audit the plan" },
+    ];
+    expect(applyReplacements("I live in New York today", rules)).toBe(
+      "I live in NYC today",
+    );
+    expect(applyReplacements("Prompt 1", rules)).toBe("Audit the plan");
+  });
+
+  it("should replace a multi-word source that carries trailing punctuation", () => {
+    const rules = [
+      { sourceValue: "Prompt 1", destinationValue: "Audit the plan" },
+    ];
+    // Speech-to-text habitually ends a short utterance with a period; the
+    // trigger's punctuation is preserved on the replacement, as it is for
+    // single-word rules.
+    expect(applyReplacements("Prompt 1.", rules)).toBe("Audit the plan.");
+  });
+
+  it("should match a multi-word source regardless of case", () => {
+    const rules = [{ sourceValue: "New York", destinationValue: "NYC" }];
+    expect(applyReplacements("i love new york", rules)).toBe("i love NYC");
+  });
+
+  it("should prefer the longest matching phrase", () => {
+    const rules = [
+      { sourceValue: "New York", destinationValue: "NYC" },
+      { sourceValue: "New York City", destinationValue: "The Big Apple" },
+    ];
+    expect(applyReplacements("Welcome to New York City now", rules)).toBe(
+      "Welcome to The Big Apple now",
+    );
+  });
+
+  it("should replace multiple occurrences of a multi-word source", () => {
+    const rules = [{ sourceValue: "foo bar", destinationValue: "baz" }];
+    expect(applyReplacements("foo bar and foo bar", rules)).toBe("baz and baz");
+  });
+
+  it("should preserve surrounding whitespace around multi-word matches", () => {
+    const rules = [{ sourceValue: "foo bar", destinationValue: "baz" }];
+    expect(applyReplacements("  foo bar   end  ", rules)).toBe("  baz   end  ");
+  });
+
+  it("should not match a phrase split across a newline boundary incorrectly", () => {
+    const rules = [{ sourceValue: "foo bar", destinationValue: "baz" }];
+    // The words are still adjacent, just separated by a newline.
+    expect(applyReplacements("foo\nbar", rules)).toBe("baz");
+  });
+
+  it("should not partially match a multi-word source", () => {
+    const rules = [{ sourceValue: "New York", destinationValue: "NYC" }];
+    expect(applyReplacements("New Jersey is nearby", rules)).toBe(
+      "New Jersey is nearby",
+    );
+    expect(applyReplacements("York alone stays", rules)).toBe(
+      "York alone stays",
+    );
+  });
+
+  it("should still apply single-word rules alongside multi-word rules", () => {
+    const rules = [
+      { sourceValue: "LLM", destinationValue: "Claude" },
+      { sourceValue: "New York", destinationValue: "NYC" },
+    ];
+    expect(applyReplacements("LLM in New York", rules)).toBe("Claude in NYC");
+  });
+
   it("should choose best match when multiple rules could apply", () => {
     const rules = [
       { sourceValue: "test", destinationValue: "exam" },

--- a/apps/desktop/src/utils/string.utils.ts
+++ b/apps/desktop/src/utils/string.utils.ts
@@ -129,50 +129,122 @@ export const sanitizeIndentation = (text: string): string => {
     .join("\n");
 };
 
+const collapseWhitespace = (text: string): string => text.replace(/\s+/g, " ");
+
+/**
+ * Canonical form used to compare a rule's source against a candidate span:
+ * internal whitespace collapsed, surrounding punctuation stripped.
+ */
+const normalizePhrase = (phrase: string): string =>
+  extractPunctuation(collapseWhitespace(phrase.trim())).word;
+
+const countWords = (phrase: string): number => {
+  const trimmed = phrase.trim();
+  return trimmed ? trimmed.split(/\s+/).length : 0;
+};
+
 export const applyReplacements = (
   text: string,
   rules: ReplacementRule[],
 ): string => {
   if (rules.length === 0) return text;
 
-  const words = text.split(/(\s+)/);
+  const segments = text.split(/(\s+)/);
+
+  // Positions of the word segments; the odd indices in between are whitespace.
+  const wordPositions: number[] = [];
+  for (let i = 0; i < segments.length; i++) {
+    const segment = segments[i];
+    if (segment && !/^\s+$/.test(segment)) {
+      wordPositions.push(i);
+    }
+  }
+
+  // Rules are matched as phrases, so a rule spans as many words as its source
+  // does. Longer phrases are tried first so that "New York City" wins over a
+  // "New York" rule at the same position.
+  const preparedRules = rules
+    .map((rule) => ({
+      rule,
+      source: normalizePhrase(rule.sourceValue).toLowerCase(),
+      wordCount: countWords(rule.sourceValue),
+    }))
+    .filter((prepared) => prepared.source.length > 0);
+
+  if (preparedRules.length === 0) return text;
+
+  const maxWordCount = Math.max(
+    ...preparedRules.map((prepared) => prepared.wordCount),
+  );
+
   const result: string[] = [];
+  let segmentIndex = 0;
+  let wordIndex = 0;
 
-  for (const segment of words) {
-    if (/^\s+$/.test(segment)) {
-      result.push(segment);
-      continue;
+  while (wordIndex < wordPositions.length) {
+    const startSegment = wordPositions[wordIndex];
+
+    // Emit whitespace (and anything else) preceding this word untouched.
+    while (segmentIndex < startSegment) {
+      result.push(segments[segmentIndex]);
+      segmentIndex++;
     }
 
-    const { word, leadingPunctuation, trailingPunctuation } =
-      extractPunctuation(segment);
+    const remainingWords = wordPositions.length - wordIndex;
+    let matched = false;
 
-    if (!word) {
-      result.push(segment);
-      continue;
-    }
+    for (
+      let span = Math.min(maxWordCount, remainingWords);
+      span >= 1 && !matched;
+      span--
+    ) {
+      const endSegment = wordPositions[wordIndex + span - 1];
+      const candidate = segments.slice(startSegment, endSegment + 1).join("");
+      const { word, leadingPunctuation, trailingPunctuation } =
+        extractPunctuation(candidate);
 
-    let bestMatch: ReplacementRule | null = null;
-    let bestSimilarity = 0;
+      if (!word) continue;
 
-    for (const rule of rules) {
-      const { word: ruleWord } = extractPunctuation(rule.sourceValue);
-      if (!ruleWord) continue;
+      const normalizedCandidate = collapseWhitespace(word).toLowerCase();
 
-      const similarity = getStringSimilarity(
-        word.toLowerCase(),
-        ruleWord.toLowerCase(),
-      );
-      if (similarity >= SIMILARITY_THRESHOLD && similarity > bestSimilarity) {
-        bestSimilarity = similarity;
-        bestMatch = rule;
+      let bestMatch: ReplacementRule | null = null;
+      let bestSimilarity = 0;
+
+      for (const prepared of preparedRules) {
+        if (prepared.wordCount !== span) continue;
+
+        const similarity = getStringSimilarity(
+          normalizedCandidate,
+          prepared.source,
+        );
+        if (similarity >= SIMILARITY_THRESHOLD && similarity > bestSimilarity) {
+          bestSimilarity = similarity;
+          bestMatch = prepared.rule;
+        }
+      }
+
+      if (bestMatch) {
+        const { word: destinationWord } = extractPunctuation(
+          bestMatch.destinationValue,
+        );
+        result.push(leadingPunctuation + destinationWord + trailingPunctuation);
+        segmentIndex = endSegment + 1;
+        wordIndex += span;
+        matched = true;
       }
     }
 
-    const { word: destinationWord } = bestMatch
-      ? extractPunctuation(bestMatch.destinationValue)
-      : { word };
-    result.push(leadingPunctuation + destinationWord + trailingPunctuation);
+    if (!matched) {
+      result.push(segments[startSegment]);
+      segmentIndex = startSegment + 1;
+      wordIndex++;
+    }
+  }
+
+  // Emit any trailing whitespace.
+  while (segmentIndex < segments.length) {
+    result.push(segments[segmentIndex]);
+    segmentIndex++;
   }
 
   return result.join("");


### PR DESCRIPTION
## What changed?

Replacement rules with a multi-word source (e.g. `New York` → `NYC`, or the docs' own `sig block` example) never fire. `applyReplacements` splits the transcript on whitespace and compares **one token at a time** against the entire `sourceValue`, so a two-word source can never reach the 0.95 similarity threshold — the rule is silently ignored.

**Repro (current main):**
```ts
applyReplacements("I live in New York today", [
  { sourceValue: "New York", destinationValue: "NYC" },
]);
// expected: "I live in NYC today"
// actual:   "I live in New York today"
```

**Fix:** match candidate spans of consecutive words, sized by each rule's word count, trying longer phrases first so `New York City` wins over `New York` at the same position. Everything else is intentionally unchanged:

- single-word rules take the exact same path as before (all existing tests pass unmodified)
- same 0.95 fuzzy threshold, applied to the normalized phrase
- case-insensitive matching preserved
- leading/trailing punctuation of the matched span is preserved around the replacement, exactly as it was for single words (`"Prompt 1."` → `"<replacement>."`)
- whitespace layout outside matches is untouched

## How is it tested?

- [x] Automated tests
- [ ] Manual verification
- [x] Code inspection

Added 9 unit tests in `string.utils.test.ts` covering: basic multi-word expansion, trailing punctuation, case-insensitivity, longest-phrase-wins, repeated occurrences, whitespace preservation, matches across newlines, no partial matches (`New Jersey` untouched by a `New York` rule), and single + multi-word rules together.

`vitest run src` on this branch: 229 passed, 0 failed (baseline main: 220 passed, 0 failed — the 3 test files that fail to *load* fail identically on main and are unrelated). `prettier --check` and `oxlint` clean on the touched files.
