### PR TITLE
chore(mobile): ship iOS dictation language persistence fix

### DIFF
--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -1,7 +1,7 @@
 name: app
 description: "A new Flutter project."
 publish_to: "none"
-version: 1.5.0+37
+version: 1.5.1+38
 
 environment:
   sdk: ^3.10.3


### PR DESCRIPTION
## What changed?

Bumps the mobile app from `1.5.0+37` to `1.5.1+38`.

Build 37 predates `dd4d01cd`, which stopped profile sync from overwriting the dictation language selected in the iOS keyboard. A new build is required to ship that fix.

The language fix is already in `main`; this PR only advances the version used by the iOS release.

Closes #480.

## How is it tested?

- [ ] Automated tests
- [ ] Manual verification
- [x] Code inspection

Verified that:

- `dd4d01cd` is an ancestor of this branch.
- `syncUserToKeyboard()` sends only the user name.
- iOS `setKeyboardUser` no longer writes `voquill_dictation_language`.
- The release build number is newer than `+37`.

This work was prepared on Linux without Flutter/FVM or Xcode. We could not build an iOS archive or test the activation flow on a device.

Manual verification remains required on a Mac and iPhone through Xcode or TestFlight:

1. Select Spanish in the Voquill keyboard.
2. Activate Voquill and return to the keyboard.
3. Confirm the `ES` indicator remains active.
4. Dictate in Spanish and confirm the transcription also uses Spanish.
