### PR TITLE
feat(desktop): switch dictation language from the tray icon

### DIFF
--- a/apps/desktop/CONTEXT.md
+++ b/apps/desktop/CONTEXT.md
@@ -1,0 +1,23 @@
+# Desktop
+
+The Voquill desktop dictation app (Tauri: Rust native layer + TypeScript/React brain).
+
+## Language
+
+These four terms all describe "what language the user is dictating in", but they are distinct and were previously easy to conflate.
+
+**Primary Dictation Language**:
+The user's configured default dictation language. Persisted as `preferredLanguage`; falls back to the system locale when unset. This is what the settings dialog's top selector edits.
+_Avoid_: default language, main language
+
+**Active Dictation Language**:
+The currently-selected dictation language, sticky across recordings until the user changes it. Persisted as `activeDictationLanguage`, where the sentinel value `primary` means "follow the Primary Dictation Language". This is what the tray language switcher sets.
+_Avoid_: current language, selected language
+
+**Dictation Language Override**:
+A transient, single-recording language forced by holding an additional-language hotkey. Lives in memory only and resets to null after the recording stops. Takes precedence over the Active Dictation Language.
+_Avoid_: temporary language, hotkey language
+
+**Auto Mode**:
+The dictation language value `auto`, meaning the transcription engine detects the spoken language itself rather than being told. A selectable language value, not a separate setting.
+_Avoid_: auto-detect (as a noun), detection mode

--- a/apps/desktop/docs/adr/0001-tray-language-menu-is-ts-driven.md
+++ b/apps/desktop/docs/adr/0001-tray-language-menu-is-ts-driven.md
@@ -1,0 +1,7 @@
+# Tray language menu is TypeScript-driven
+
+The tray's dictation-language submenu is built and kept in sync by TypeScript, not Rust. TypeScript computes the menu model (language code + display label + checked flag) from app state and pushes it to Rust via a command; Rust only rebuilds the native submenu from that list and emits an event when an item is clicked. A TypeScript side-effect re-pushes the menu whenever the Active Dictation Language or the configured language set changes.
+
+## Why
+
+The repo rule is "Rust is the API, TypeScript is the Brain" — decision logic and the canonical language list/labels already live in TypeScript (`language.utils.ts`). The alternative, having Rust read preferences from SQLite and build the menu itself, would duplicate that language data in Rust and let it drift. The push model also means a single mechanism keeps the tray correct after both a tray click and a settings edit. The existing `set_menu_icon` command (which toggles a tray item from TypeScript) is the precedent; this extends the same pattern from one item to a rebuildable submenu.

--- a/apps/desktop/src-tauri/src/app.rs
+++ b/apps/desktop/src-tauri/src/app.rs
@@ -268,6 +268,7 @@ pub fn build() -> tauri::Builder<tauri::Wry> {
             crate::commands::hotkey_delete,
             crate::commands::set_tray_title,
             crate::commands::set_menu_icon,
+            crate::commands::set_tray_language_menu,
             crate::commands::set_tray_visible,
             crate::commands::api_key_create,
             crate::commands::api_key_list,

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -1901,6 +1901,15 @@ pub fn set_menu_icon(
 
 #[tauri::command]
 #[specta::specta]
+pub fn set_tray_language_menu(
+    app: AppHandle,
+    items: Vec<crate::system::tray::TrayLanguageMenuItem>,
+) -> Result<(), String> {
+    crate::system::tray::set_tray_language_menu(&app, items)
+}
+
+#[tauri::command]
+#[specta::specta]
 pub fn set_tray_visible(app: AppHandle, visible: bool) -> Result<(), String> {
     use tauri::tray::TrayIconId;
     if let Some(tray) = app.tray_by_id(&TrayIconId::new("main")) {

--- a/apps/desktop/src-tauri/src/system/tray.rs
+++ b/apps/desktop/src-tauri/src/system/tray.rs
@@ -31,17 +31,29 @@ pub enum MenuIconVariant {
 
 use crate::domain::EVT_REGISTER_CURRENT_APP;
 use std::sync::OnceLock;
-use tauri::menu::MenuItem;
+use tauri::menu::{MenuItem, Submenu};
 
 pub const EVT_INSTALL_UPDATE: &str = "tray-install-update";
 pub const EVT_COPY_LAST_TRANSCRIPT: &str = "tray-copy-last-transcript";
+pub const EVT_SET_DICTATION_LANGUAGE: &str = "tray-set-dictation-language";
+
+const TRAY_LANGUAGE_ITEM_PREFIX: &str = "tray-lang:";
 
 static UPDATE_MENU_ITEM: OnceLock<MenuItem<tauri::Wry>> = OnceLock::new();
+static LANGUAGE_SUBMENU: OnceLock<Submenu<tauri::Wry>> = OnceLock::new();
+
+#[derive(Debug, Clone, serde::Deserialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub struct TrayLanguageMenuItem {
+    pub code: String,
+    pub label: String,
+    pub checked: bool,
+}
 
 #[cfg(desktop)]
 pub fn setup_tray(app: &mut tauri::App) -> tauri::Result<()> {
     use tauri::image::Image;
-    use tauri::menu::MenuBuilder;
+    use tauri::menu::{MenuBuilder, SubmenuBuilder};
     use tauri::tray::TrayIconBuilder;
     use tauri::{Emitter, Manager};
 
@@ -63,12 +75,15 @@ pub fn setup_tray(app: &mut tauri::App) -> tauri::Result<()> {
         true,
         None::<&str>,
     )?;
+    let language_submenu = SubmenuBuilder::new(app, "Language").build()?;
+    let _ = LANGUAGE_SUBMENU.set(language_submenu.clone());
     let quit_item = MenuItem::with_id(app, "quit-voquill", "Quit Voquill", true, None::<&str>)?;
 
     let menu = MenuBuilder::new(app)
         .item(&open_item)
         .item(&copy_last_transcript_item)
         .item(&register_current_app_item)
+        .item(&language_submenu)
         .item(&update_item)
         .separator()
         .item(&quit_item)
@@ -103,6 +118,12 @@ pub fn setup_tray(app: &mut tauri::App) -> tauri::Result<()> {
                 }
             }
             "quit-voquill" => app.exit(0),
+            other if other.starts_with(TRAY_LANGUAGE_ITEM_PREFIX) => {
+                let code = other[TRAY_LANGUAGE_ITEM_PREFIX.len()..].to_string();
+                if let Err(err) = app.emit(EVT_SET_DICTATION_LANGUAGE, code) {
+                    log::error!("Failed to emit set-dictation-language event: {err}");
+                }
+            }
             _ => {}
         });
 
@@ -142,6 +163,38 @@ pub fn set_menu_icon(app: &tauri::AppHandle, variant: MenuIconVariant) -> Result
     {
         tray.set_icon_as_template(true)
             .map_err(|err| err.to_string())?;
+    }
+
+    Ok(())
+}
+
+pub fn set_tray_language_menu(
+    app: &tauri::AppHandle,
+    items: Vec<TrayLanguageMenuItem>,
+) -> Result<(), String> {
+    use tauri::menu::CheckMenuItem;
+
+    let submenu = LANGUAGE_SUBMENU
+        .get()
+        .ok_or("Language submenu not initialized")?;
+
+    let existing_count = submenu.items().map_err(|err| err.to_string())?.len();
+    for _ in 0..existing_count {
+        submenu.remove_at(0).map_err(|err| err.to_string())?;
+    }
+
+    for item in &items {
+        let id = format!("{TRAY_LANGUAGE_ITEM_PREFIX}{}", item.code);
+        let check_item = CheckMenuItem::with_id(
+            app,
+            id.as_str(),
+            item.label.as_str(),
+            true,
+            item.checked,
+            None::<&str>,
+        )
+        .map_err(|err| err.to_string())?;
+        submenu.append(&check_item).map_err(|err| err.to_string())?;
     }
 
     Ok(())

--- a/apps/desktop/src/actions/onboarding.actions.ts
+++ b/apps/desktop/src/actions/onboarding.actions.ts
@@ -10,6 +10,7 @@ import { getAppState, produceAppState } from "../store";
 import { CURRENT_COHORT } from "../utils/analytics.utils";
 import { DEFAULT_DICTATION_LIMIT_MINUTES } from "../utils/dictation-limit.utils";
 import { getIsEnterpriseEnabled } from "../utils/enterprise.utils";
+import { PRIMARY_LANGUAGE_SENTINEL } from "../utils/language.utils";
 import {
   EMAIL_TONE_ID,
   POLISHED_TONE_ID,
@@ -184,6 +185,7 @@ export const submitOnboarding = async () => {
           : null,
       lastSeenFeature: null,
       isEnterprise: getIsEnterpriseEnabled(),
+      activeDictationLanguage: PRIMARY_LANGUAGE_SENTINEL,
       preferredMicrophone: normalizedMicrophone,
       ignoreUpdateDialog: false,
       incognitoModeEnabled: false,

--- a/apps/desktop/src/actions/user.actions.ts
+++ b/apps/desktop/src/actions/user.actions.ts
@@ -21,6 +21,7 @@ import {
   normalizeDictationLimitMinutes,
 } from "../utils/dictation-limit.utils";
 import { getIsEnterpriseEnabled } from "../utils/enterprise.utils";
+import { PRIMARY_LANGUAGE_SENTINEL } from "../utils/language.utils";
 import {
   isGpuPreferredTranscriptionDevice,
   normalizeLocalWhisperModel,
@@ -101,6 +102,7 @@ export const createDefaultPreferences = (): UserPreferences => ({
   openclawToken: null,
   lastSeenFeature: null,
   isEnterprise: false,
+  activeDictationLanguage: PRIMARY_LANGUAGE_SENTINEL,
   preferredMicrophone: null,
   ignoreUpdateDialog: false,
   incognitoModeEnabled: false,
@@ -418,6 +420,14 @@ export const setPreferredLanguage = async (
     "Unable to update preferred language. User not found.",
     "Failed to save preferred language. Please try again.",
   );
+};
+
+export const setActiveDictationLanguage = async (
+  language: string,
+): Promise<void> => {
+  await updateUserPreferences((preferences) => {
+    preferences.activeDictationLanguage = language;
+  }, "Failed to save active dictation language. Please try again.");
 };
 
 export const setInteractionChimeEnabled = async (enabled: boolean) => {

--- a/apps/desktop/src/components/root/AppSideEffects.tsx
+++ b/apps/desktop/src/components/root/AppSideEffects.tsx
@@ -31,6 +31,7 @@ import {
 import {
   migrateLocalUserToCloud,
   refreshCurrentUser,
+  setActiveDictationLanguage,
   setRemoteOutputEnabled,
   setRemoteTargetDeviceId,
 } from "../../actions/user.actions";
@@ -74,6 +75,7 @@ import { sendPillFlashMessage } from "../../utils/overlay.utils";
 import { isPermissionAuthorized } from "../../utils/permission.utils";
 import { getPlatform } from "../../utils/platform.utils";
 import { minutesToMilliseconds } from "../../utils/time.utils";
+import { buildTrayLanguageMenuModel } from "../../utils/tray-language.utils";
 import {
   getEffectivePillVisibility,
   getMyUserPreferences,
@@ -694,6 +696,22 @@ export const AppSideEffects = () => {
       console.error,
     );
   }, [menuBarIconHidden]);
+
+  // Re-push the tray Language submenu whenever the Active Dictation Language or
+  // the configured language set changes, keeping the tray correct after both
+  // tray clicks and settings edits.
+  const trayLanguageMenuKey = useAppStore((state) =>
+    JSON.stringify(buildTrayLanguageMenuModel(state)),
+  );
+  useEffect(() => {
+    invoke("set_tray_language_menu", {
+      items: JSON.parse(trayLanguageMenuKey),
+    }).catch(console.error);
+  }, [trayLanguageMenuKey]);
+
+  useTauriListen<string>("tray-set-dictation-language", (code) => {
+    setActiveDictationLanguage(code).catch(console.error);
+  });
 
   return null;
 };

--- a/apps/desktop/src/repos/preferences.repo.test.ts
+++ b/apps/desktop/src/repos/preferences.repo.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { createDefaultPreferences } from "../actions/user.actions";
+import { fromLocalPreferences, toLocalPreferences } from "./preferences.repo";
+
+const localPrefsWithActiveLanguage = (
+  activeDictationLanguage: string | null,
+) => ({
+  ...toLocalPreferences(createDefaultPreferences()),
+  activeDictationLanguage,
+});
+
+describe("preferences round-trip", () => {
+  it("preserves a non-primary active dictation language across load then save", () => {
+    const loaded = fromLocalPreferences(localPrefsWithActiveLanguage("es"));
+    expect(loaded.activeDictationLanguage).toBe("es");
+
+    const saved = toLocalPreferences(loaded);
+    expect(saved.activeDictationLanguage).toBe("es");
+  });
+
+  it("does not reset the active dictation language on an unrelated preference change", () => {
+    const loaded = fromLocalPreferences(localPrefsWithActiveLanguage("es"));
+    loaded.preferredMicrophone = "USB Microphone";
+
+    const saved = toLocalPreferences(loaded);
+    expect(saved.activeDictationLanguage).toBe("es");
+    expect(saved.preferredMicrophone).toBe("USB Microphone");
+  });
+
+  it("writes the primary sentinel when no active dictation language is set", () => {
+    const loaded = fromLocalPreferences(localPrefsWithActiveLanguage(null));
+    expect(loaded.activeDictationLanguage).toBeNull();
+
+    const saved = toLocalPreferences(loaded);
+    expect(saved.activeDictationLanguage).toBe("primary");
+  });
+});

--- a/apps/desktop/src/repos/preferences.repo.ts
+++ b/apps/desktop/src/repos/preferences.repo.ts
@@ -11,6 +11,7 @@ import {
   DEFAULT_DICTATION_LIMIT_MINUTES,
   normalizeDictationLimitMinutes,
 } from "../utils/dictation-limit.utils";
+import { PRIMARY_LANGUAGE_SENTINEL } from "../utils/language.utils";
 import { getEffectivePillVisibility, LOCAL_USER_ID } from "../utils/user.utils";
 import { BaseRepo } from "./base.repo";
 
@@ -68,7 +69,7 @@ const normalizePostProcessingMode = (
   return "none";
 };
 
-const fromLocalPreferences = (
+export const fromLocalPreferences = (
   preferences: LocalUserPreferences,
 ): UserPreferences => ({
   userId: preferences.userId,
@@ -91,6 +92,7 @@ const fromLocalPreferences = (
   openclawToken: preferences.openclawToken ?? null,
   lastSeenFeature: preferences.lastSeenFeature,
   isEnterprise: preferences.isEnterprise,
+  activeDictationLanguage: preferences.activeDictationLanguage ?? null,
   preferredMicrophone: preferences.preferredMicrophone ?? null,
   ignoreUpdateDialog: preferences.ignoreUpdateDialog ?? false,
   incognitoModeEnabled: preferences.incognitoModeEnabled ?? false,
@@ -113,7 +115,7 @@ const fromLocalPreferences = (
   typingSpeedMs: preferences.typingSpeedMs ?? null,
 });
 
-const toLocalPreferences = (
+export const toLocalPreferences = (
   preferences: UserPreferences,
 ): LocalUserPreferences => ({
   userId: LOCAL_USER_ID,
@@ -136,7 +138,8 @@ const toLocalPreferences = (
   isEnterprise: preferences.isEnterprise,
   languageSwitchEnabled: false,
   secondaryDictationLanguage: null,
-  activeDictationLanguage: "primary",
+  activeDictationLanguage:
+    preferences.activeDictationLanguage ?? PRIMARY_LANGUAGE_SENTINEL,
   preferredMicrophone: preferences.preferredMicrophone ?? null,
   ignoreUpdateDialog: preferences.ignoreUpdateDialog ?? false,
   incognitoModeEnabled: preferences.incognitoModeEnabled ?? false,

--- a/apps/desktop/src/utils/language.utils.ts
+++ b/apps/desktop/src/utils/language.utils.ts
@@ -121,6 +121,12 @@ export const WHISPER_LANGUAGES = {
 
 export const AUTO_LANGUAGE = "auto";
 
+/**
+ * Sentinel value stored as the Active Dictation Language meaning "follow the
+ * Primary Dictation Language" rather than a concrete language code.
+ */
+export const PRIMARY_LANGUAGE_SENTINEL = "primary";
+
 /** These are all the supported languages. Anything not supported by Whisper needs to be post processed into the language of choice */
 export const DICTATION_LANGUAGES = {
   [AUTO_LANGUAGE]: "Auto-detect",

--- a/apps/desktop/src/utils/tray-language.utils.test.ts
+++ b/apps/desktop/src/utils/tray-language.utils.test.ts
@@ -1,0 +1,128 @@
+import type { Hotkey, User, UserPreferences } from "@voquill/types";
+import { describe, expect, it } from "vitest";
+import { AppState, INITIAL_APP_STATE } from "../state/app.state";
+import { buildTrayLanguageMenuModel } from "./tray-language.utils";
+import { LOCAL_USER_ID } from "./user.utils";
+
+const additionalLanguageHotkey = (language: string): Hotkey => ({
+  id: `hotkey-${language}`,
+  actionName: `additional-language:${language}`,
+  keys: ["KeyZ"],
+});
+
+const makeState = (args: {
+  primaryLanguage?: string | null;
+  activeDictationLanguage?: string | null;
+  additionalLanguages?: string[];
+}): AppState => {
+  const hotkeyById: Record<string, Hotkey> = {};
+  for (const language of args.additionalLanguages ?? []) {
+    const hotkey = additionalLanguageHotkey(language);
+    hotkeyById[hotkey.id] = hotkey;
+  }
+
+  return {
+    ...INITIAL_APP_STATE,
+    userById: {
+      [LOCAL_USER_ID]: {
+        preferredLanguage: args.primaryLanguage ?? null,
+      } as User,
+    },
+    userPrefs: {
+      activeDictationLanguage: args.activeDictationLanguage ?? null,
+    } as UserPreferences,
+    hotkeyById,
+  };
+};
+
+const checkedCodes = (items: { code: string; checked: boolean }[]): string[] =>
+  items.filter((item) => item.checked).map((item) => item.code);
+
+describe("buildTrayLanguageMenuModel", () => {
+  it("lists the primary follow entry, additional languages, and auto", () => {
+    const items = buildTrayLanguageMenuModel(
+      makeState({ primaryLanguage: "en", additionalLanguages: ["es", "fr"] }),
+    );
+    expect(items.map((item) => item.code)).toEqual([
+      "primary",
+      "es",
+      "fr",
+      "auto",
+    ]);
+  });
+
+  it("renders the primary as the sentinel entry labelled with the language name", () => {
+    const [primary] = buildTrayLanguageMenuModel(
+      makeState({ primaryLanguage: "en" }),
+    );
+    expect(primary.code).toBe("primary");
+    expect(primary.label).toBe("English");
+  });
+
+  it("checks the primary entry when following the primary", () => {
+    const items = buildTrayLanguageMenuModel(
+      makeState({
+        primaryLanguage: "en",
+        activeDictationLanguage: "primary",
+        additionalLanguages: ["es"],
+      }),
+    );
+    expect(checkedCodes(items)).toEqual(["primary"]);
+  });
+
+  it("checks the active concrete language", () => {
+    const items = buildTrayLanguageMenuModel(
+      makeState({
+        primaryLanguage: "en",
+        activeDictationLanguage: "es",
+        additionalLanguages: ["es"],
+      }),
+    );
+    expect(checkedCodes(items)).toEqual(["es"]);
+  });
+
+  it("checks auto when active", () => {
+    const items = buildTrayLanguageMenuModel(
+      makeState({ primaryLanguage: "en", activeDictationLanguage: "auto" }),
+    );
+    expect(checkedCodes(items)).toEqual(["auto"]);
+  });
+
+  it("always yields exactly one checked entry", () => {
+    const items = buildTrayLanguageMenuModel(
+      makeState({
+        primaryLanguage: "en",
+        activeDictationLanguage: "secondary",
+        additionalLanguages: ["es", "fr"],
+      }),
+    );
+    expect(checkedCodes(items)).toEqual(["primary"]);
+  });
+
+  it("does not render a duplicate auto row when the primary is itself auto", () => {
+    const items = buildTrayLanguageMenuModel(
+      makeState({
+        primaryLanguage: "auto",
+        activeDictationLanguage: "primary",
+      }),
+    );
+    expect(items.map((item) => item.code)).toEqual(["primary"]);
+    expect(items[0].label).toBe("Auto-detect");
+    expect(checkedCodes(items)).toEqual(["primary"]);
+  });
+
+  it("keeps exactly one checked entry when the primary is auto and auto is active", () => {
+    const items = buildTrayLanguageMenuModel(
+      makeState({ primaryLanguage: "auto", activeDictationLanguage: "auto" }),
+    );
+    expect(items.map((item) => item.code)).toEqual(["primary"]);
+    expect(checkedCodes(items)).toEqual(["primary"]);
+  });
+
+  it("still lists auto when the primary is keyboard-layout", () => {
+    const items = buildTrayLanguageMenuModel(
+      makeState({ primaryLanguage: "keyboard-layout" }),
+    );
+    expect(items.map((item) => item.code)).toEqual(["primary", "auto"]);
+  });
+});

--- a/apps/desktop/src/utils/tray-language.utils.ts
+++ b/apps/desktop/src/utils/tray-language.utils.ts
@@ -1,0 +1,73 @@
+import type { AppState } from "../state/app.state";
+import { getAdditionalLanguageEntries } from "./keyboard.utils";
+import {
+  AUTO_LANGUAGE,
+  DICTATION_LANGUAGE_OPTIONS,
+  getDisplayNameForLanguage,
+  PRIMARY_LANGUAGE_SENTINEL,
+} from "./language.utils";
+import {
+  getActiveDictationLanguage,
+  getMyPrimaryDictationLanguage,
+} from "./user.utils";
+
+export type TrayLanguageMenuItem = {
+  code: string;
+  label: string;
+  checked: boolean;
+};
+
+const getDictationLanguageLabel = (code: string): string => {
+  const option = DICTATION_LANGUAGE_OPTIONS.find(([value]) => value === code);
+  return option ? option[1] : getDisplayNameForLanguage(code);
+};
+
+/**
+ * Maps app state to the tray Language submenu model: the Primary (rendered as
+ * the `primary` follow entry), each additional configured language, and Auto.
+ * Deduplicates by code so a Primary that is itself `auto`/`keyboard-layout`
+ * does not produce a duplicate row, and yields exactly one checked entry
+ * tracking the Active Dictation Language.
+ */
+export const buildTrayLanguageMenuModel = (
+  state: AppState,
+): TrayLanguageMenuItem[] => {
+  const primaryCode = getMyPrimaryDictationLanguage(state);
+  const active = getActiveDictationLanguage(state);
+  const checkedCode =
+    active === PRIMARY_LANGUAGE_SENTINEL || active === primaryCode
+      ? PRIMARY_LANGUAGE_SENTINEL
+      : active;
+
+  const items: TrayLanguageMenuItem[] = [];
+  const seen = new Set<string>();
+
+  items.push({
+    code: PRIMARY_LANGUAGE_SENTINEL,
+    label: getDictationLanguageLabel(primaryCode),
+    checked: checkedCode === PRIMARY_LANGUAGE_SENTINEL,
+  });
+  seen.add(primaryCode);
+
+  for (const entry of getAdditionalLanguageEntries(state)) {
+    if (seen.has(entry.language)) {
+      continue;
+    }
+    seen.add(entry.language);
+    items.push({
+      code: entry.language,
+      label: getDictationLanguageLabel(entry.language),
+      checked: checkedCode === entry.language,
+    });
+  }
+
+  if (!seen.has(AUTO_LANGUAGE)) {
+    items.push({
+      code: AUTO_LANGUAGE,
+      label: getDictationLanguageLabel(AUTO_LANGUAGE),
+      checked: checkedCode === AUTO_LANGUAGE,
+    });
+  }
+
+  return items;
+};

--- a/apps/desktop/src/utils/user.utils.test.ts
+++ b/apps/desktop/src/utils/user.utils.test.ts
@@ -1,0 +1,172 @@
+import type { Hotkey, User, UserPreferences } from "@voquill/types";
+import { describe, expect, it } from "vitest";
+import { AppState, INITIAL_APP_STATE } from "../state/app.state";
+import {
+  getActiveDictationLanguage,
+  getConfiguredDictationLanguageCodes,
+  getMyDictationLanguage,
+  LOCAL_USER_ID,
+} from "./user.utils";
+
+const additionalLanguageHotkey = (language: string): Hotkey => ({
+  id: `hotkey-${language}`,
+  actionName: `additional-language:${language}`,
+  keys: ["KeyZ"],
+});
+
+const makeState = (args: {
+  primaryLanguage?: string | null;
+  activeDictationLanguage?: string | null;
+  additionalLanguages?: string[];
+  override?: string | null;
+}): AppState => {
+  const hotkeyById: Record<string, Hotkey> = {};
+  for (const language of args.additionalLanguages ?? []) {
+    const hotkey = additionalLanguageHotkey(language);
+    hotkeyById[hotkey.id] = hotkey;
+  }
+
+  return {
+    ...INITIAL_APP_STATE,
+    dictationLanguageOverride: args.override ?? null,
+    userById: {
+      [LOCAL_USER_ID]: {
+        preferredLanguage: args.primaryLanguage ?? null,
+      } as User,
+    },
+    userPrefs:
+      args.activeDictationLanguage === undefined
+        ? null
+        : ({
+            activeDictationLanguage: args.activeDictationLanguage,
+          } as UserPreferences),
+    hotkeyById,
+  };
+};
+
+describe("getConfiguredDictationLanguageCodes", () => {
+  it("always includes auto", () => {
+    const codes = getConfiguredDictationLanguageCodes(makeState({}));
+    expect(codes.has("auto")).toBe(true);
+  });
+
+  it("includes additional configured languages", () => {
+    const codes = getConfiguredDictationLanguageCodes(
+      makeState({ additionalLanguages: ["es", "fr"] }),
+    );
+    expect(codes.has("es")).toBe(true);
+    expect(codes.has("fr")).toBe(true);
+  });
+
+  it("does not include the primary concrete code", () => {
+    const codes = getConfiguredDictationLanguageCodes(
+      makeState({ primaryLanguage: "en" }),
+    );
+    expect(codes.has("en")).toBe(false);
+  });
+});
+
+describe("getActiveDictationLanguage", () => {
+  it("returns the sentinel when unset", () => {
+    expect(getActiveDictationLanguage(makeState({}))).toBe("primary");
+  });
+
+  it("returns the sentinel when explicitly set to primary", () => {
+    expect(
+      getActiveDictationLanguage(
+        makeState({ activeDictationLanguage: "primary" }),
+      ),
+    ).toBe("primary");
+  });
+
+  it("honors a configured concrete code", () => {
+    expect(
+      getActiveDictationLanguage(
+        makeState({
+          activeDictationLanguage: "es",
+          additionalLanguages: ["es"],
+        }),
+      ),
+    ).toBe("es");
+  });
+
+  it("falls through to the sentinel for a stale value not in the configured set", () => {
+    expect(
+      getActiveDictationLanguage(
+        makeState({ activeDictationLanguage: "secondary" }),
+      ),
+    ).toBe("primary");
+  });
+
+  it("falls through to the sentinel when the active language was removed from the set", () => {
+    expect(
+      getActiveDictationLanguage(
+        makeState({
+          activeDictationLanguage: "es",
+          additionalLanguages: ["fr"],
+        }),
+      ),
+    ).toBe("primary");
+  });
+
+  it("honors auto since it is always configured", () => {
+    expect(
+      getActiveDictationLanguage(
+        makeState({ activeDictationLanguage: "auto" }),
+      ),
+    ).toBe("auto");
+  });
+});
+
+describe("getMyDictationLanguage", () => {
+  it("lets a transient override take precedence over the active language", () => {
+    const state = makeState({
+      primaryLanguage: "en",
+      activeDictationLanguage: "es",
+      additionalLanguages: ["es"],
+      override: "fr",
+    });
+    expect(getMyDictationLanguage(state)).toBe("fr");
+  });
+
+  it("uses the active language over the primary", () => {
+    const state = makeState({
+      primaryLanguage: "en",
+      activeDictationLanguage: "es",
+      additionalLanguages: ["es"],
+    });
+    expect(getMyDictationLanguage(state)).toBe("es");
+  });
+
+  it("follows the primary when the active language is the sentinel", () => {
+    const state = makeState({
+      primaryLanguage: "en",
+      activeDictationLanguage: "primary",
+    });
+    expect(getMyDictationLanguage(state)).toBe("en");
+  });
+
+  it("follows the primary for a stale value (upgrade safety)", () => {
+    const state = makeState({
+      primaryLanguage: "en",
+      activeDictationLanguage: "secondary",
+    });
+    expect(getMyDictationLanguage(state)).toBe("en");
+  });
+
+  it("passes auto through as the active language", () => {
+    const state = makeState({
+      primaryLanguage: "en",
+      activeDictationLanguage: "auto",
+    });
+    expect(getMyDictationLanguage(state)).toBe("auto");
+  });
+
+  it("passes a keyboard-layout primary through when following the primary", () => {
+    const state = makeState({
+      primaryLanguage: "keyboard-layout",
+      activeDictationLanguage: "primary",
+    });
+    expect(getMyDictationLanguage(state)).toBe("keyboard-layout");
+  });
+});

--- a/apps/desktop/src/utils/user.utils.ts
+++ b/apps/desktop/src/utils/user.utils.ts
@@ -23,11 +23,13 @@ import {
   getAllowsChangePostProcessing,
   getAllowsChangeTranscription,
 } from "./enterprise.utils";
+import { getAdditionalLanguageEntries } from "./keyboard.utils";
 import {
   AUTO_LANGUAGE,
   coerceToDictationLanguage,
   DictationLanguageCode,
   KEYBOARD_LAYOUT_LANGUAGE,
+  PRIMARY_LANGUAGE_SENTINEL,
 } from "./language.utils";
 import { getEffectivePlan, getMemberExceedsLimitByState } from "./member.utils";
 
@@ -112,11 +114,51 @@ export const getMyPrimaryDictationLanguage = (state: AppState): string => {
   return getDetectedSystemLocale();
 };
 
+/**
+ * The set of concrete dictation language codes the user has configured and may
+ * therefore select as their Active Dictation Language. Auto is always available;
+ * the rest come from the additional-language hotkeys. The Primary is represented
+ * by the `primary` sentinel, not a concrete code, so it is not included here.
+ */
+export const getConfiguredDictationLanguageCodes = (
+  state: AppState,
+): Set<string> => {
+  const codes = new Set<string>([AUTO_LANGUAGE]);
+  for (const entry of getAdditionalLanguageEntries(state)) {
+    codes.add(entry.language);
+  }
+  return codes;
+};
+
+/**
+ * The Active Dictation Language as a sentinel-or-code, with the stale-value
+ * guard applied: the persisted value is honored only when it is the `primary`
+ * sentinel or a member of the current configured set; otherwise it falls
+ * through to the sentinel (follow Primary). Guards against stale values written
+ * by the since-removed language-switch feature and against a previously-active
+ * language later removed from the configured set.
+ */
+export const getActiveDictationLanguage = (state: AppState): string => {
+  const stored = state.userPrefs?.activeDictationLanguage;
+  if (!stored || stored === PRIMARY_LANGUAGE_SENTINEL) {
+    return PRIMARY_LANGUAGE_SENTINEL;
+  }
+  if (getConfiguredDictationLanguageCodes(state).has(stored)) {
+    return stored;
+  }
+  return PRIMARY_LANGUAGE_SENTINEL;
+};
+
 export const getMyDictationLanguage = (state: AppState): string => {
   // TODO: We should pass the dictation language into the processors instead of overriding
   const override = state.dictationLanguageOverride;
   if (override) {
     return override;
+  }
+
+  const active = getActiveDictationLanguage(state);
+  if (active !== PRIMARY_LANGUAGE_SENTINEL) {
+    return active;
   }
 
   return getMyPrimaryDictationLanguage(state);

--- a/packages/types/src/preferences.types.ts
+++ b/packages/types/src/preferences.types.ts
@@ -24,6 +24,7 @@ export type UserPreferences = {
   openclawGatewayUrl: Nullable<string>;
   openclawToken: Nullable<string>;
   lastSeenFeature: Nullable<string>;
+  activeDictationLanguage: Nullable<string>;
   preferredMicrophone: Nullable<string>;
   ignoreUpdateDialog: boolean;
   incognitoModeEnabled: boolean;


### PR DESCRIPTION
## What changed?

Adds a **Language** submenu to the tray icon so you can switch dictation language without opening the main window. It lists the Primary language (as a "follow primary" entry), each additional configured language, and Auto, with a checkmark on the Active Dictation Language. Picking one applies immediately, stays sticky across recordings, and leaves your configured Primary untouched.

Along the way it reconnects the `activeDictationLanguage` preference boundary, which was severed (hardcoded to `"primary"` in the SQLite mapping). The field now round-trips through `@voquill/types` and `fromLocalPreferences`/`toLocalPreferences`, so an unrelated preference save no longer resets the tray selection. Language resolution is Override → Active → Primary → locale, with a guard that honors the persisted value only when it is the primary sentinel or a member of the current configured set (upgrade-safety against the removed legacy language-switch feature; no migration needed).

The submenu is TypeScript-driven per ADR 0001 (`apps/desktop/docs/adr/0001-tray-language-menu-is-ts-driven.md`), following the existing `set_menu_icon` precedent: TS computes a pure `{code, label, checked}[]` model and pushes it to Rust via `set_tray_language_menu`; Rust rebuilds the native `CheckMenuItem`s and emits `tray-set-dictation-language` on click. A side-effect re-pushes the menu whenever the Active language or the configured set changes, keeping the tray and the settings dialog in sync.

Closes #452.

## How is it tested?

- [x] Automated tests: unit tests for the menu model (`tray-language.utils.test.ts`), language resolution (`user.utils.test.ts`), and the preference round-trip (`preferences.repo.test.ts`).
- [x] Manual verification: built and ran on Linux (X11/GNOME). The submenu renders Primary + Auto, and picking a different entry moves the checkmark live with no restart. Dictation transcribing in the picked language was not exercised in my environment (no cloud login / local model available).
- [x] Code inspection

🤖 Generated with [Claude Code](https://claude.com/claude-code)
