### PR TITLE
Fix Windows updater signature verification failures

### DIFF
--- a/.github/workflows/_release-desktop-impl.yml
+++ b/.github/workflows/_release-desktop-impl.yml
@@ -872,9 +872,20 @@ jobs:
           Write-Host "Uploading $destName to release $env:RELEASE_TAG"
           gh release upload $env:RELEASE_TAG $destName --clobber
 
+  # Azure Trusted Signing (above) rewrites the NSIS exe after Tauri computed
+  # its updater signature, so the sig and latest.json must be regenerated from
+  # the final bytes before the channel manifest is published.
+  resign-windows-updater:
+    name: Re-sign Windows updater
+    needs: [metadata, build]
+    uses: ./.github/workflows/resign-windows-updater.yml
+    with:
+      release_tag: ${{ needs.metadata.outputs.tag_name }}
+    secrets: inherit
+
   update-channel:
     name: Update channel release
-    needs: [metadata, build]
+    needs: [metadata, build, resign-windows-updater]
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/resign-windows-updater.yml
+++ b/.github/workflows/resign-windows-updater.yml
@@ -1,0 +1,97 @@
+name: Re-sign Windows updater
+
+# Azure Trusted Signing modifies the NSIS installer *after* Tauri generates its
+# minisign updater signature, which invalidates it and breaks auto-updates with
+# "signature verification failed". This workflow re-signs the final exe bytes,
+# patches latest.json, and verifies every signature in the manifest before
+# publishing. It runs as part of the desktop release pipeline and can be
+# dispatched manually to repair an already-published release.
+
+on:
+  workflow_call:
+    inputs:
+      release_tag:
+        description: "Release tag holding the artifacts (e.g. desktop-v0.0.650)"
+        required: true
+        type: string
+      channel_tag:
+        description: "Channel tag that should also receive the patched latest.json (e.g. desktop-prod)"
+        required: false
+        type: string
+        default: ""
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: "Release tag holding the artifacts (e.g. desktop-v0.0.650)"
+        required: true
+        type: string
+      channel_tag:
+        description: "Channel tag that should also receive the patched latest.json (e.g. desktop-prod)"
+        required: false
+        type: string
+        default: ""
+
+jobs:
+  resign:
+    name: Re-sign and verify updater signatures
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_REPO: ${{ github.repository }}
+      RELEASE_TAG: ${{ inputs.release_tag }}
+      CHANNEL_TAG: ${{ inputs.channel_tag }}
+    steps:
+      - name: Download latest.json and updater artifacts
+        run: |
+          set -euo pipefail
+          mkdir -p dist
+          gh release download "$RELEASE_TAG" --pattern "latest.json" --dir dist --clobber
+          jq -r '.platforms[].url | sub(".*/"; "")' dist/latest.json | sort -u | while read -r asset; do
+            gh release download "$RELEASE_TAG" --pattern "$asset" --dir dist --clobber
+          done
+
+      - name: Re-sign NSIS installers
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_PRIVATE_KEY_PASSWORD }}
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          for exe in dist/*-setup.exe; do
+            npx --yes @tauri-apps/cli@2 signer sign "$exe"
+            sig="$(cat "${exe}.sig")"
+            name="$(basename "$exe")"
+            jq --arg name "$name" --arg sig "$sig" \
+              '.platforms |= with_entries(if (.value.url | endswith("/" + $name)) then .value.signature = $sig else . end)' \
+              dist/latest.json > dist/latest.json.tmp
+            mv dist/latest.json.tmp dist/latest.json
+          done
+
+      - name: Verify every signature in latest.json
+        env:
+          TAURI_UPDATER_PUBLIC_KEY: ${{ secrets.TAURI_UPDATER_PUBLIC_KEY }}
+        run: |
+          set -euo pipefail
+          sudo apt-get update -qq >/dev/null
+          sudo apt-get install -y -qq minisign >/dev/null
+          pub="$( (base64 -d <<<"$TAURI_UPDATER_PUBLIC_KEY" 2>/dev/null || printf '%s' "$TAURI_UPDATER_PUBLIC_KEY") | grep -m1 '^RW' )"
+          jq -r '.platforms | to_entries[] | [.key, (.value.url | sub(".*/"; "")), .value.signature] | @tsv' dist/latest.json \
+          | while IFS=$'\t' read -r platform asset sig; do
+              printf '%s' "$sig" | base64 -d > asset.minisig
+              minisign -Vm "dist/$asset" -x asset.minisig -P "$pub" >/dev/null
+              echo "verified: $platform ($asset)"
+            done
+
+      - name: Publish re-signed artifacts
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          for sig in dist/*-setup.exe.sig; do
+            gh release upload "$RELEASE_TAG" "$sig" --clobber
+          done
+          gh release upload "$RELEASE_TAG" dist/latest.json --clobber
+          if [[ -n "$CHANNEL_TAG" ]]; then
+            gh release upload "$CHANNEL_TAG" dist/latest.json --clobber
+          fi


### PR DESCRIPTION
## Root cause

The release pipeline Authenticode-signs the NSIS installer with Azure Trusted Signing **after** `tauri-action` has already generated the minisign updater signature, then re-uploads the modified exe with `--clobber`. The `.sig` asset and `latest.json` still reference the pre-Authenticode bytes, so every NSIS-installed client fails auto-update with "signature verification failed".

Verified empirically against the live release assets using the updater pubkey (`E45E18761D47A527`) extracted from the shipping app:

| Artifact | Updater signature |
|---|---|
| `Voquill_0.0.641_x64-setup.exe` | ❌ invalid |
| `Voquill_0.0.644_x64-setup.exe` | ❌ invalid |
| `Voquill_0.0.650_x64-setup.exe` | ❌ invalid |
| `Voquill_0.0.650_x64_en-US.msi` | ✅ valid |
| `Voquill_universal.app.tar.gz` (macOS) | ✅ valid |

MSI installs update fine (nothing touches the MSI after Tauri signs it), which is why only some Windows users hit this. "Redownload from the website" doesn't help because the website ships the NSIS build — it just fails again at the next release.

## Fix

New `resign-windows-updater.yml` workflow (reusable + manually dispatchable):

1. Downloads `latest.json` and the updater artifacts from the version release
2. Re-signs `*-setup.exe` with the updater key — over the final, Azure-signed bytes
3. Patches the matching signatures in `latest.json`
4. **Verifies every platform signature in the manifest with minisign** — the release now fails loudly instead of shipping a broken manifest (this guard would have caught the bug months ago)
5. Uploads the new `.sig` and `latest.json` (and optionally to a channel tag)

Wired into `_release-desktop-impl.yml` between `build` and `update-channel`, so the channel manifest can only publish verified signatures.

The re-sign/patch/verify logic was tested locally against the real 0.0.650 release assets with a throwaway keypair: all entries verify, including the re-signed NSIS installer.

## After merging

Dispatch the workflow to repair the live releases without shipping a new version — existing 0.0.644 clients will then update successfully:

```
gh workflow run resign-windows-updater.yml -f release_tag=desktop-v0.0.650 -f channel_tag=desktop-prod
```

(and similarly for the latest dev/enterprise release tags, which have the same breakage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)