### PR TITLE
Promote release workflow fix to prod

### DIFF
--- a/.github/workflows/_release-desktop-impl.yml
+++ b/.github/workflows/_release-desktop-impl.yml
@@ -165,9 +165,14 @@ jobs:
             DEV_TAG_NAME="${TARGET_DEV_TAG}"
           fi
 
-          if git rev-parse -q --verify "refs/tags/${TAG_NAME}" >/dev/null; then
-            echo "Tag ${TAG_NAME} already exists. Aborting." >&2
-            exit 1
+          TAG_EXISTS="false"
+          if EXISTING_SHA="$(git rev-parse -q --verify "refs/tags/${TAG_NAME}^{commit}")"; then
+            if [[ "${EXISTING_SHA}" != "${COMMIT_SHA}" ]]; then
+              echo "Tag ${TAG_NAME} already exists at ${EXISTING_SHA}, expected ${COMMIT_SHA}. Aborting." >&2
+              exit 1
+            fi
+            echo "Tag ${TAG_NAME} already exists at the target commit; reusing it."
+            TAG_EXISTS="true"
           fi
 
           VERSION_PATH="desktop/${RELEASE_ENV}/${VERSION}"
@@ -211,6 +216,7 @@ jobs:
             echo "version_path=${VERSION_PATH}"
             echo "channel_release_tag=${CHANNEL_RELEASE_TAG}"
             echo "release_flavor=${RELEASE_FLAVOR}"
+            echo "tag_exists=${TAG_EXISTS}"
           } >> "$GITHUB_OUTPUT"
 
       - name: Read release notes
@@ -226,12 +232,19 @@ jobs:
           body="$(cat "${notes_file}")"
           printf 'release_body<<EOF\n%s\nEOF\n' "$body" >> "$GITHUB_OUTPUT"
 
+      # GITHUB_TOKEN cannot create a ref to a commit whose workflow files differ
+      # from the current branch head (GitHub demands workflows:write, which
+      # GITHUB_TOKEN can never hold). Prod promotions tag the older dev commit,
+      # so they hit this whenever a workflow changed since that dev release —
+      # RELEASE_TAG_TOKEN (PAT with contents+workflows write) covers that case.
       - name: Create release tag
+        if: steps.meta.outputs.tag_exists != 'true'
         uses: actions/github-script@v7
         env:
           TAG_NAME: ${{ steps.meta.outputs.tag_name }}
           TARGET_SHA: ${{ steps.meta.outputs.commit_sha }}
         with:
+          github-token: ${{ secrets.RELEASE_TAG_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
             const tagName = process.env.TAG_NAME;
             const targetSha = process.env.TARGET_SHA;

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,10 +9,36 @@ name: Release (auto)
 # Promotion: fast-forward merge `main` into `prod` or `enterprise` → this
 # workflow runs on that branch and only the components that changed since
 # the last release on that branch ship.
+#
+# Manual dispatch releases the selected components on the chosen branch —
+# the recovery path when a push-triggered release fails, since reruns use
+# the original (broken) workflow snapshot.
 
 on:
   push:
     branches: [main, prod, enterprise]
+  workflow_dispatch:
+    inputs:
+      desktop:
+        description: "Release desktop"
+        type: boolean
+        default: false
+      cli:
+        description: "Release CLI"
+        type: boolean
+        default: false
+      docs:
+        description: "Release docs"
+        type: boolean
+        default: false
+      enterprise_admin:
+        description: "Release enterprise admin"
+        type: boolean
+        default: false
+      enterprise_gateway:
+        description: "Release enterprise gateway"
+        type: boolean
+        default: false
 
 concurrency:
   group: release-${{ github.ref_name }}-orchestrator
@@ -30,11 +56,11 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       channel: ${{ steps.env.outputs.channel }}
-      cli: ${{ steps.filter.outputs.cli }}
-      desktop: ${{ steps.filter.outputs.desktop }}
-      docs: ${{ steps.filter.outputs.docs }}
-      enterprise_admin: ${{ steps.filter.outputs.enterprise_admin }}
-      enterprise_gateway: ${{ steps.filter.outputs.enterprise_gateway }}
+      cli: ${{ github.event_name == 'workflow_dispatch' && inputs.cli || steps.filter.outputs.cli }}
+      desktop: ${{ github.event_name == 'workflow_dispatch' && inputs.desktop || steps.filter.outputs.desktop }}
+      docs: ${{ github.event_name == 'workflow_dispatch' && inputs.docs || steps.filter.outputs.docs }}
+      enterprise_admin: ${{ github.event_name == 'workflow_dispatch' && inputs.enterprise_admin || steps.filter.outputs.enterprise_admin }}
+      enterprise_gateway: ${{ github.event_name == 'workflow_dispatch' && inputs.enterprise_gateway || steps.filter.outputs.enterprise_gateway }}
     steps:
       - uses: actions/checkout@v4
 
@@ -48,6 +74,7 @@ jobs:
           esac
 
       - uses: dorny/paths-filter@v3
+        if: github.event_name == 'push'
         id: filter
         with:
           base: ${{ github.event.before }}


### PR DESCRIPTION
Brings the fix for the failed desktop-v0.0.651 promotion (run 30707224957) to prod so the release can be re-dispatched. See ef8572a3 for details.

🤖 Generated with [Claude Code](https://claude.com/claude-code)