### PR TITLE
fix(desktop): bundle GStreamer so AppImage clip playback works on Linux

### DIFF
--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -67,7 +67,7 @@
         "depends": ["xdotool", "vulkan-loader", "gtk-layer-shell", "wtype"]
       },
       "appimage": {
-        "bundleMediaFramework": false
+        "bundleMediaFramework": true
       }
     }
   },


### PR DESCRIPTION
## What changed?

Transcription clip playback fails on every clip in the Linux AppImage with "Unable to play audio snippet."

`bundle.linux.appimage.bundleMediaFramework` is set to `false`, so the AppImage ships **zero GStreamer plugins**. WebKitGTK decodes and plays Web Audio through GStreamer, so `AudioContext` / `AudioBuffer` playback has no decoder and no output sink, and fails for every clip regardless of length or content.

Tauri's AppImage docs call this out directly: apps that play audio or video need `bundleMediaFramework` enabled, since that is what pulls the GStreamer plugins into the bundle.

The `.deb` and `.rpm` builds are unaffected — they link against the system GStreamer, which is why this doesn't reproduce when developing or running from those.

## Root cause detail

The AppImage bundles GStreamer **core** libraries (`libgstreamer-1.0.so.0`, `libgstaudio`, `libgstbase`, …) at version **1.20.3**, but no plugins. GStreamer refuses to load plugins built against a different core version, so the system's plugins are all rejected and nothing is left to decode with.

This is awkward to diagnose from the outside: the Rust side logs nothing (the error is caught in the webview), and release builds have devtools compiled out, so the console message is unreachable.

## Verification

Rebuilt the AppImage locally with the flag enabled:

| | official 0.0.651 | rebuilt |
|---|---|---|
| bundled GStreamer plugins | **0** | **121** |
| `wavparse`, `audioconvert`, `audioresample` | absent | present |
| `pulseaudio` / `alsa` sinks | absent | present |
| clip playback | fails on every clip | **works** |

Also confirmed playback works in a `tauri dev` build (system GStreamer), which matches the `.deb` / `.rpm` behaviour and isolates the problem to AppImage packaging.

**Environment:** Ubuntu 26.04, GNOME 50.1 Wayland, WebKitGTK 2.52.3, system GStreamer 1.28.2, Voquill 0.0.651 AppImage.

## Trade-off worth your call

The AppImage grew **105 MB → 188 MB** in my build. Tauri's docs suggest 15–35 MB, so this is on the high side — `linuxdeploy-plugin-gstreamer` takes all 121 system plugins rather than only the audio ones.

Happy to scope it down (e.g. via `GSTREAMER_PLUGINS_DIR`, or trimming to the audio set) if bundle size matters more than the simplicity of the documented flag. I kept the first pass minimal rather than pre-emptively optimising something you may have an opinion about.

## Related

#276 moved Linux playback off the Web Audio path to work around this. It was closed as superseded by #296, but #296 contained only the pasting fixes, so the playback problem was never addressed and is still present in 0.0.651. This fixes it at the packaging layer instead, leaving application code untouched.

## How is it tested?

- [x] Manual verification on Linux — rebuilt AppImage, all clips play
- [x] Code inspection
- [ ] Automated tests
